### PR TITLE
Add path constraints UI and export/time support

### DIFF
--- a/plugins/pedro.d.ts
+++ b/plugins/pedro.d.ts
@@ -281,6 +281,11 @@ interface TimelineEvent {
   velocityProfile?: number[];
   // Detailed heading profile for travel events: maps step index to unwrapped heading
   headingProfile?: number[];
+  // When a path constraint (tValue/velocity) shortens the segment, this is the
+  // curve parameter (0–1) where the robot actually stops. Absent or 1 means full path.
+  constraintEndT?: number;
+  // Physical position at constraintEndT (in field inches). Used as next segment's start.
+  constraintEndPoint?: BasePoint;
 }
 
 interface TimePrediction {

--- a/plugins/pedro.d.ts
+++ b/plugins/pedro.d.ts
@@ -59,6 +59,14 @@ interface EventMarker {
   parameters?: Record<string, any>;
 }
 
+interface PathConstraints {
+  timeout?: number;
+  tValue?: number;
+  velocity?: number;
+  translational?: number;
+  heading?: number;
+}
+
 interface WaitSegment {
   name?: string;
   durationMs: number;
@@ -84,6 +92,7 @@ interface Line {
   isMacroElement?: boolean;
   macroId?: string;
   originalId?: string;
+  constraints?: PathConstraints;
 }
 
 type SequencePathItem = {

--- a/src/lib/components/sections/ConstraintsSection.svelte
+++ b/src/lib/components/sections/ConstraintsSection.svelte
@@ -66,52 +66,8 @@
 
   {#if !collapsed}
     <div class="p-3 bg-white dark:bg-neutral-800 border-t border-neutral-200 dark:border-neutral-700 grid grid-cols-2 gap-3">
-      
-      <!-- Timeout -->
-      <div class="space-y-1">
-        <label for={`timeout-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
-          <div class="flex items-center gap-1.5">
-            <span>Timeout (ms)</span>
-            <div class="relative flex items-center">
-              <!-- svelte-ignore a11y-no-static-element-interactions -->
-              <svg 
-                xmlns="http://www.w3.org/2000/svg" 
-                viewBox="0 0 20 20" 
-                fill="currentColor" 
-                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
-                on:mouseenter={(e) => handleHoverEnter(e, `timeout-${line.id}`)}
-                on:mouseleave={handleHoverLeave}
-              >
-                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
-              </svg>
-              {#if hoveredHoverId === `timeout-${line.id}`}
-                <div 
-                  use:tooltipPortal={hoveredHoverAnchor}
-                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
-                >
-                <div class="font-bold mb-1">Timeout Constraint</div>
-                How long the follower has to correct after stopping before the path is considered complete.<br/><br/>
-                <span class="text-purple-300">Recommended:</span> Increase for better accuracy at the end of the path. Decrease for faster transitions between paths.
-                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
-                </div>
-              {/if}
-            </div>
-          </div>
-        </label>
-        <input
-          id={`timeout-${line.id}`}
-          type="number"
-          min="0"
-          step="100"
-          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
-          bind:value={constraints.timeout}
-          on:change={handleInput}
-          disabled={line.locked}
-          placeholder="e.g. 500"
-        />
-      </div>
 
-      <!-- TValue -->
+      <!-- T-Value -->
       <div class="space-y-1">
         <label for={`tvalue-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
           <div class="flex items-center gap-1.5">
@@ -134,8 +90,7 @@
                   class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
                 >
                 <div class="font-bold mb-1">T-Value Constraint</div>
-                The parametric end criteria. How much of the path the robot must follow before it is considered complete.<br/><br/>
-                <span class="text-purple-300">Recommended:</span> 0.95 to 0.99. If the robot gets stuck at the end of a path, try decreasing this slightly so it finishes earlier. Decreasing too much leads to incomplete paths. 
+                The parametric end criteria. How much of the path the robot must follow before it is considered complete.
                 <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
                 </div>
               {/if}
@@ -179,8 +134,7 @@
                   class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
                 >
                 <div class="font-bold mb-1">Velocity Constraint</div>
-                The maximum velocity the robot must be below for the path to be considered complete.<br/><br/>
-                <span class="text-purple-300">Recommended:</span> Low values (~1-3 in/s) for precise stops. Higher values if you want to flow into the next action before fully stopping.
+                The maximum velocity the robot must be below for the path to be considered complete.
                 <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
                 </div>
               {/if}
@@ -197,6 +151,49 @@
           on:change={handleInput}
           disabled={line.locked}
           placeholder="e.g. 10"
+        />
+      </div>
+
+      <!-- Heading -->
+      <div class="space-y-1">
+        <label for={`heading-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>Heading (deg)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `heading-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `heading-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">Heading Error Constraint</div>
+                The maximum allowable rotational error for the path to be considered complete.
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`heading-${line.id}`}
+          type="number"
+          min="0"
+          step="0.5"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.heading}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 2.0"
         />
       </div>
 
@@ -223,8 +220,7 @@
                   class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
                 >
                 <div class="font-bold mb-1">Translational Error Constraint</div>
-                The maximum allowable translational (X/Y) error for the path to be considered complete.<br/><br/>
-                <span class="text-purple-300">Recommended:</span> Small values (~0.5-1.0 in) for precision. Increase if the robot struggles to settle on the exact target.
+                The maximum allowable translational (X/Y) error for the path to be considered complete.
                 <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
                 </div>
               {/if}
@@ -244,11 +240,11 @@
         />
       </div>
 
-      <!-- Heading -->
+      <!-- Timeout (spans full width — it's the cooldown after all other constraints are met) -->
       <div class="space-y-1 col-span-2">
-        <label for={`heading-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+        <label for={`timeout-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
           <div class="flex items-center gap-1.5">
-            <span>Heading (deg)</span>
+            <span>Timeout (ms)</span>
             <div class="relative flex items-center">
               <!-- svelte-ignore a11y-no-static-element-interactions -->
               <svg 
@@ -256,19 +252,18 @@
                 viewBox="0 0 20 20" 
                 fill="currentColor" 
                 class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
-                on:mouseenter={(e) => handleHoverEnter(e, `heading-${line.id}`)}
+                on:mouseenter={(e) => handleHoverEnter(e, `timeout-${line.id}`)}
                 on:mouseleave={handleHoverLeave}
               >
                 <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
               </svg>
-              {#if hoveredHoverId === `heading-${line.id}`}
+              {#if hoveredHoverId === `timeout-${line.id}`}
                 <div 
                   use:tooltipPortal={hoveredHoverAnchor}
                   class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
                 >
-                <div class="font-bold mb-1">Heading Error Constraint</div>
-                The maximum allowable rotational error for the path to be considered complete.<br/><br/>
-                <span class="text-purple-300">Recommended:</span> Small values (~1-3 deg) for precision. Increase if the robot continues oscillating near the target heading.
+                <div class="font-bold mb-1">Timeout Constraint</div>
+                How long the follower has to correct after stopping before the path is considered complete.
                 <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
                 </div>
               {/if}
@@ -276,15 +271,15 @@
           </div>
         </label>
         <input
-          id={`heading-${line.id}`}
+          id={`timeout-${line.id}`}
           type="number"
           min="0"
-          step="0.5"
+          step="100"
           class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
-          bind:value={constraints.heading}
+          bind:value={constraints.timeout}
           on:change={handleInput}
           disabled={line.locked}
-          placeholder="e.g. 2.0"
+          placeholder="e.g. 500"
         />
       </div>
 

--- a/src/lib/components/sections/ConstraintsSection.svelte
+++ b/src/lib/components/sections/ConstraintsSection.svelte
@@ -1,0 +1,293 @@
+<!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
+<script lang="ts">
+  import type { Line } from "../../../types/index";
+  import { tooltipPortal } from "../../actions/portal";
+
+  export let line: Line;
+  export let collapsed: boolean = true;
+  export let recordChange: (action?: string) => void;
+
+  function handleInput() {
+    recordChange("Update Constraints");
+  }
+
+  $: {
+    if (!line.constraints) {
+      line.constraints = {};
+    }
+  }
+
+  function toggleCollapsed() {
+    collapsed = !collapsed;
+  }
+
+  // Tooltip anchors and states
+  let hoveredHoverId: string | null = null;
+  let hoveredHoverAnchor: HTMLElement | null = null;
+
+  function handleHoverEnter(e: MouseEvent, id: string) {
+    hoveredHoverId = id;
+    hoveredHoverAnchor = e.currentTarget as HTMLElement;
+  }
+  
+  function handleHoverLeave() {
+    hoveredHoverId = null;
+    hoveredHoverAnchor = null;
+  }
+
+  // Workaround for Svelte typescript bindings
+  $: constraints = line.constraints!;
+</script>
+
+<div class="mt-4 border border-neutral-200 dark:border-neutral-700 rounded-lg overflow-hidden bg-white dark:bg-neutral-800">
+  <button
+    on:click|stopPropagation={toggleCollapsed}
+    class="w-full flex items-center justify-between p-2.5 bg-neutral-50 dark:bg-neutral-900/50 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+  >
+    <div class="flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="2.5"
+        stroke="currentColor"
+        class="size-3.5 text-neutral-500 transition-transform duration-200 {collapsed ? '-rotate-90' : 'rotate-0'}"
+      >
+        <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+      </svg>
+      <span class="text-xs font-bold uppercase tracking-wider text-neutral-600 dark:text-neutral-400">Path Constraints</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <span class="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-neutral-200 dark:bg-neutral-700 text-neutral-600 dark:text-neutral-300">
+        {Object.values(line.constraints || {}).filter(v => v !== undefined && v !== null && v !== "").length} Active
+      </span>
+    </div>
+  </button>
+
+  {#if !collapsed}
+    <div class="p-3 bg-white dark:bg-neutral-800 border-t border-neutral-200 dark:border-neutral-700 grid grid-cols-2 gap-3">
+      
+      <!-- Timeout -->
+      <div class="space-y-1">
+        <label for={`timeout-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>Timeout (ms)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `timeout-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `timeout-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">Timeout Constraint</div>
+                How long the follower has to correct after stopping before the path is considered complete.<br/><br/>
+                <span class="text-purple-300">Recommended:</span> Increase for better accuracy at the end of the path. Decrease for faster transitions between paths.
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`timeout-${line.id}`}
+          type="number"
+          min="0"
+          step="100"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.timeout}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 500"
+        />
+      </div>
+
+      <!-- TValue -->
+      <div class="space-y-1">
+        <label for={`tvalue-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>T-Value (0.0 - 1.0)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `tvalue-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `tvalue-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">T-Value Constraint</div>
+                The parametric end criteria. How much of the path the robot must follow before it is considered complete.<br/><br/>
+                <span class="text-purple-300">Recommended:</span> 0.95 to 0.99. If the robot gets stuck at the end of a path, try decreasing this slightly so it finishes earlier. Decreasing too much leads to incomplete paths. 
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`tvalue-${line.id}`}
+          type="number"
+          min="0"
+          max="1"
+          step="0.05"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.tValue}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 0.95"
+        />
+      </div>
+
+      <!-- Velocity -->
+      <div class="space-y-1">
+        <label for={`velocity-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>Velocity (in/s)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `velocity-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `velocity-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">Velocity Constraint</div>
+                The maximum velocity the robot must be below for the path to be considered complete.<br/><br/>
+                <span class="text-purple-300">Recommended:</span> Low values (~1-3 in/s) for precise stops. Higher values if you want to flow into the next action before fully stopping.
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`velocity-${line.id}`}
+          type="number"
+          min="0"
+          step="1"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.velocity}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 10"
+        />
+      </div>
+
+      <!-- Translational -->
+      <div class="space-y-1">
+        <label for={`translational-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>Translational (in)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `translational-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `translational-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">Translational Error Constraint</div>
+                The maximum allowable translational (X/Y) error for the path to be considered complete.<br/><br/>
+                <span class="text-purple-300">Recommended:</span> Small values (~0.5-1.0 in) for precision. Increase if the robot struggles to settle on the exact target.
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`translational-${line.id}`}
+          type="number"
+          min="0"
+          step="0.1"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.translational}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 1.0"
+        />
+      </div>
+
+      <!-- Heading -->
+      <div class="space-y-1 col-span-2">
+        <label for={`heading-${line.id}`} class="text-xs font-medium text-neutral-500 flex justify-between items-center">
+          <div class="flex items-center gap-1.5">
+            <span>Heading (deg)</span>
+            <div class="relative flex items-center">
+              <!-- svelte-ignore a11y-no-static-element-interactions -->
+              <svg 
+                xmlns="http://www.w3.org/2000/svg" 
+                viewBox="0 0 20 20" 
+                fill="currentColor" 
+                class="w-3.5 h-3.5 text-neutral-400 hover:text-neutral-500 cursor-help transition-colors"
+                on:mouseenter={(e) => handleHoverEnter(e, `heading-${line.id}`)}
+                on:mouseleave={handleHoverLeave}
+              >
+                <path fill-rule="evenodd" d="M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-7-4a1 1 0 1 1-2 0 1 1 0 0 1 2 0ZM9 9a.75.75 0 0 0 0 1.5h.253a.25.25 0 0 1 .244.304l-.459 2.066A1.75 1.75 0 0 0 10.747 15H11a.75.75 0 0 0 0-1.5h-.253a.25.25 0 0 1-.244-.304l.459-2.066A1.75 1.75 0 0 0 9.253 9H9Z" clip-rule="evenodd" />
+              </svg>
+              {#if hoveredHoverId === `heading-${line.id}`}
+                <div 
+                  use:tooltipPortal={hoveredHoverAnchor}
+                  class="w-64 p-2 bg-neutral-900 text-white text-[10px] leading-relaxed rounded shadow-xl z-50 pointer-events-none"
+                >
+                <div class="font-bold mb-1">Heading Error Constraint</div>
+                The maximum allowable rotational error for the path to be considered complete.<br/><br/>
+                <span class="text-purple-300">Recommended:</span> Small values (~1-3 deg) for precision. Increase if the robot continues oscillating near the target heading.
+                <div class="absolute -bottom-1 left-1/2 -translate-x-1/2 border-4 border-transparent border-t-neutral-900"></div>
+                </div>
+              {/if}
+            </div>
+          </div>
+        </label>
+        <input
+          id={`heading-${line.id}`}
+          type="number"
+          min="0"
+          step="0.5"
+          class="w-full px-2 py-1.5 text-sm bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-md focus:ring-2 focus:ring-purple-500/20 focus:border-purple-500 outline-none transition-all disabled:opacity-50"
+          bind:value={constraints.heading}
+          on:change={handleInput}
+          disabled={line.locked}
+          placeholder="e.g. 2.0"
+        />
+      </div>
+
+    </div>
+  {/if}
+</div>

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -3,6 +3,7 @@
   import type { Line } from "../../../types/index";
   import { snapToGrid, showGrid, gridSize } from "../../../stores";
   import ControlPointsSection from "./ControlPointsSection.svelte";
+  import ConstraintsSection from "./ConstraintsSection.svelte";
   import HeadingControls from "../HeadingControls.svelte";
   import ColorPicker from "../tools/ColorPicker.svelte";
   import {
@@ -28,6 +29,7 @@
   export let collapsed: boolean;
   // export let collapsedEventMarkers: boolean;
   export let collapsedControlPoints: boolean;
+  export let collapsedConstraints: boolean = true;
   export let onRemove: () => void;
   export let onInsertAfter: () => void;
   export let onAddWaitAfter: () => void;
@@ -437,6 +439,12 @@
         bind:line
         lineIdx={idx}
         bind:collapsed={collapsedControlPoints}
+        {recordChange}
+      />
+
+      <ConstraintsSection
+        bind:line
+        bind:collapsed={collapsedConstraints}
         {recordChange}
       />
 

--- a/src/tests/animation.test.ts
+++ b/src/tests/animation.test.ts
@@ -132,6 +132,58 @@ describe("animation", () => {
       // Heading interpolation: 0 to 90 at 0.5 -> 45. Negated -> -45.
       expect(state.heading).toBeCloseTo(-45);
     });
+
+    it("should respect constraintEndT — robot stops at mid-path, not full endpoint", () => {
+      // Line from (0,0) to (10,0). constraintEndT=0.5 means robot stops at (5,0).
+      const constrainedTimeline: TimelineEvent[] = [
+        {
+          type: "travel",
+          duration: 1.0,
+          startTime: 0,
+          endTime: 1.0,
+          lineIndex: 0,
+          motionProfile: [0, 1.0],
+          constraintEndT: 0.5, // Robot only travels half the path
+        },
+      ];
+
+      // At 100% (end of event), robot should be at x=5, not x=10
+      const state = calculateRobotState(
+        100,
+        constrainedTimeline,
+        simpleLines,
+        startPoint,
+        xScale,
+        yScale,
+      );
+      expect(state.x).toBeCloseTo(xScale(5));
+      expect(state.y).toBeCloseTo(yScale(0));
+    });
+
+    it("constraintEndT=1 (no constraint) — robot reaches full endpoint", () => {
+      const unconstrainedTimeline: TimelineEvent[] = [
+        {
+          type: "travel",
+          duration: 1.0,
+          startTime: 0,
+          endTime: 1.0,
+          lineIndex: 0,
+          motionProfile: [0, 1.0],
+          constraintEndT: 1.0,
+        },
+      ];
+
+      const state = calculateRobotState(
+        100,
+        unconstrainedTimeline,
+        simpleLines,
+        startPoint,
+        xScale,
+        yScale,
+      );
+      expect(state.x).toBeCloseTo(xScale(10));
+      expect(state.y).toBeCloseTo(yScale(0));
+    });
   });
 
   describe("createAnimationController", () => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,6 +50,14 @@ export interface EventMarker {
   parameters?: Record<string, any>;
 }
 
+export interface PathConstraints {
+  timeout?: number;
+  tValue?: number;
+  velocity?: number;
+  translational?: number;
+  heading?: number;
+}
+
 export interface WaitSegment {
   name?: string;
   durationMs: number;
@@ -75,6 +83,7 @@ export interface Line {
   isMacroElement?: boolean;
   macroId?: string;
   originalId?: string;
+  constraints?: PathConstraints;
 }
 
 export type SequencePathItem = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -272,6 +272,11 @@ export interface TimelineEvent {
   velocityProfile?: number[];
   // Detailed heading profile for travel events: maps step index to unwrapped heading
   headingProfile?: number[];
+  // When a path constraint (tValue/velocity) shortens the segment, this is the
+  // curve parameter (0–1) where the robot actually stops. Absent or 1 means full path.
+  constraintEndT?: number;
+  // Physical position at constraintEndT (in field inches). Used as next segment's start.
+  constraintEndPoint?: BasePoint;
 }
 
 export interface TimePrediction {

--- a/src/utils/animation.ts
+++ b/src/utils/animation.ts
@@ -95,9 +95,12 @@ export function calculateRobotState(
       const relativeTime = Math.max(0, currentSeconds - activeEvent.startTime);
       const profileEndTime = profile[profile.length - 1];
 
+      // The effective max curve parameter — constrained paths stop before t=1
+      const maxLinePercent = activeEvent.constraintEndT ?? 1;
+
       if (relativeTime >= profileEndTime) {
         // If we exceeded the profile (e.g. rotation time extended the segment), we are at the end
-        linePercent = 1;
+        linePercent = maxLinePercent;
         if (
           activeEvent.headingProfile &&
           activeEvent.headingProfile.length > 0
@@ -146,7 +149,9 @@ export function calculateRobotState(
       linePercent = easeInOutQuad(Math.max(0, Math.min(1, timeProgress)));
     }
 
-    linePercent = Math.max(0, Math.min(1, linePercent));
+    // Clamp linePercent; respect constraintEndT so robot never passes the constraint position
+    const maxPercent = activeEvent.constraintEndT ?? 1;
+    linePercent = Math.max(0, Math.min(maxPercent, linePercent));
 
     // Calculate Position
     const robotInchesXY = getCurvePoint(linePercent, [

--- a/src/utils/codeExporter.ts
+++ b/src/utils/codeExporter.ts
@@ -188,6 +188,26 @@ export async function generateJavaCode(
               .join("");
           }
 
+          // Add constraints to the path builder
+          let constraintCode = "";
+          if (line.constraints) {
+            if (line.constraints.timeout !== undefined) {
+              constraintCode += `\n        .setTimeoutConstraint(${line.constraints.timeout})`;
+            }
+            if (line.constraints.tValue !== undefined) {
+              constraintCode += `\n        .setTValueConstraint(${line.constraints.tValue.toFixed(3)})`;
+            }
+            if (line.constraints.velocity !== undefined) {
+              constraintCode += `\n        .setVelocityConstraint(${line.constraints.velocity})`;
+            }
+            if (line.constraints.translational !== undefined) {
+              constraintCode += `\n        .setTranslationalConstraint(${line.constraints.translational.toFixed(3)})`;
+            }
+            if (line.constraints.heading !== undefined) {
+              constraintCode += `\n        .setHeadingConstraint(Math.toRadians(${line.constraints.heading.toFixed(3)}))`;
+            }
+          }
+
           return `${variableName} = follower.pathBuilder().addPath(
           ${curveType}(
             ${startCode},
@@ -195,7 +215,7 @@ export async function generateJavaCode(
             ${endCode}
           )
         ).${headingTypeToFunctionName[line.endPoint.heading]}(${headingConfig})
-        ${reverseConfig}${eventMarkerCode}
+        ${reverseConfig}${eventMarkerCode}${constraintCode}
         .build();`;
         })
         .join("\n\n")}
@@ -904,9 +924,29 @@ export async function generateSequentialCommandCode(
         ? "\n                .setReversed()"
         : "";
 
+      // Add constraints
+      let constraintCode = "";
+      if (line.constraints) {
+        if (line.constraints.timeout !== undefined) {
+          constraintCode += `\n                .setTimeoutConstraint(${line.constraints.timeout})`;
+        }
+        if (line.constraints.tValue !== undefined) {
+          constraintCode += `\n                .setTValueConstraint(${line.constraints.tValue.toFixed(3)})`;
+        }
+        if (line.constraints.velocity !== undefined) {
+          constraintCode += `\n                .setVelocityConstraint(${line.constraints.velocity})`;
+        }
+        if (line.constraints.translational !== undefined) {
+          constraintCode += `\n                .setTranslationalConstraint(${line.constraints.translational.toFixed(3)})`;
+        }
+        if (line.constraints.heading !== undefined) {
+          constraintCode += `\n                .setHeadingConstraint(Math.toRadians(${line.constraints.heading.toFixed(3)}))`;
+        }
+      }
+
       return `        ${pathName} = follower.pathBuilder()
             .addPath(new ${curveType}(${actualStartPose}, ${controlPointsStr}${endPoseVar}))
-            .${headingConfig}${reverseConfig}
+            .${headingConfig}${reverseConfig}${constraintCode}
             .build();`;
     })
     .join("\n\n        ");

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -835,24 +835,73 @@ export function calculatePathTime(
 
       let segmentTime = Math.max(translationTime, rotationTime);
 
-      // Apply Constraints to estimated time
+      // Apply Constraints — ALL must be met before moving to the next segment.
+      // Each constraint independently computes a candidate "done" time from the base.
+      // The segment ends when the LAST constraint is satisfied (max of all candidates).
+      let constraintEndT: number | undefined = undefined;
+      let constraintEndPoint: import("../types").BasePoint | undefined = undefined;
+
       if (line.constraints) {
-        // T-Value: The robot considers the path complete earlier
+        const base = segmentTime; // unmodified base time
+
+        // Collect a candidate end time (and optional t) for each constraint
+        type Candidate = { time: number; t?: number };
+        const candidates: Candidate[] = [];
+
+        // T-Value: path is done when the robot reaches tValue fraction of the curve.
+        // The time to reach tValue is base * tValue (proportional).
         if (line.constraints.tValue !== undefined) {
-          segmentTime *= line.constraints.tValue;
+          const t = Math.max(0, Math.min(1, line.constraints.tValue));
+          candidates.push({ time: base * t, t });
         }
 
-        // Velocity: The robot considers the path complete when velocity drops below this value
-        // We save the time it would take to decelerate from this velocity to zero
+        // Velocity: path is done when speed drops below this threshold.
+        // We subtract the time it takes to decelerate from that velocity to a stop.
         if (line.constraints.velocity !== undefined) {
           const maxDec = safeSettings.maxDeceleration || safeSettings.maxAcceleration || 30;
           const timeSaved = line.constraints.velocity / maxDec;
-          segmentTime = Math.max(0.001, segmentTime - timeSaved);
+          candidates.push({ time: Math.max(0.001, base - timeSaved) });
         }
 
-        // Timeout: The robot waits up to this amount of time at the end to correct
+        if (candidates.length > 0) {
+          // ALL constraints must be met: take the one that finishes last (max time).
+          // That is the moment when the robot has satisfied every constraint.
+          const winner = candidates.reduce((best, c) => c.time > best.time ? c : best);
+          segmentTime = winner.time;
+
+          if (winner.t !== undefined) {
+            // tValue constraint was the bottleneck — use directly
+            constraintEndT = winner.t;
+          } else if (motionProfile && motionProfile.length > 1) {
+            // velocity/other was bottleneck — derive t from motion profile
+            const profileEndTime = motionProfile[motionProfile.length - 1];
+            const clampedTime = Math.max(0, Math.min(segmentTime, profileEndTime));
+            let profileIdx = 0;
+            while (profileIdx < motionProfile.length - 2 && clampedTime > motionProfile[profileIdx + 1]) {
+              profileIdx++;
+            }
+            const tStart = profileIdx / (motionProfile.length - 1);
+            const tEnd = (profileIdx + 1) / (motionProfile.length - 1);
+            const timeStart = motionProfile[profileIdx];
+            const timeEnd = motionProfile[profileIdx + 1];
+            let localProgress = 0;
+            if (timeEnd > timeStart) {
+              localProgress = (clampedTime - timeStart) / (timeEnd - timeStart);
+            }
+            constraintEndT = Math.max(0, Math.min(1, tStart + localProgress * (tEnd - tStart)));
+          }
+        }
+
+        // Timeout: added AFTER all other constraints are satisfied.
+        // The robot pauses to correct before moving on.
         if (line.constraints.timeout !== undefined) {
           segmentTime += line.constraints.timeout / 1000; // ms to seconds
+        }
+
+        // Compute the physical position at constraintEndT
+        if (constraintEndT !== undefined && constraintEndT < 0.9999) {
+          const cps: import("../types").BasePoint[] = [prevPoint as import("../types").BasePoint, ...line.controlPoints, line.endPoint as import("../types").BasePoint];
+          constraintEndPoint = getCurvePoint(constraintEndT, cps as any);
         }
       }
 
@@ -869,12 +918,15 @@ export function calculatePathTime(
         motionProfile: motionProfile,
         velocityProfile: velocityProfile,
         headingProfile: headingProfile,
+        constraintEndT,
+        constraintEndPoint,
       });
       currentTime += segmentTime;
 
-      // Update state
+      // Update state — use the constraint end position so subsequent segments and
+      // rotation waits begin from the physically correct location, not the full endpoint.
       currentHeading = endHeading;
-      lastPoint = line.endPoint as Point;
+      lastPoint = (constraintEndPoint as Point | undefined) ?? (line.endPoint as Point);
     });
   };
 

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -923,9 +923,37 @@ export function calculatePathTime(
       });
       currentTime += segmentTime;
 
-      // Update state — use the constraint end position so subsequent segments and
-      // rotation waits begin from the physically correct location, not the full endpoint.
-      currentHeading = endHeading;
+      // Update state — if the segment ended early due to constraints, derive the actual
+      // heading at constraintEndT rather than using the full endpoint's heading.
+      // This ensures the next segment's rotation wait starts from the right angle.
+      if (constraintEndT !== undefined && constraintEndT < 0.9999) {
+        const cps = [prevPoint, ...line.controlPoints, line.endPoint];
+
+        if (line.endPoint.heading === "linear") {
+          // Linear heading: lerp between start heading and full-end heading at constraintEndT
+          const segStartHeading = currentHeading; // heading entering this segment
+          currentHeading = segStartHeading + (endHeading - segStartHeading) * constraintEndT;
+        } else if (line.endPoint.heading === "tangential") {
+          // Tangential: compute the actual tangent direction at constraintEndT
+          const dt = line.endPoint.reverse ? -0.001 : 0.001;
+          const tA = Math.max(0, Math.min(1, constraintEndT));
+          const tB = Math.max(0, Math.min(1, constraintEndT + dt));
+          const pA = getCurvePoint(tA, cps as any);
+          const pB = getCurvePoint(tB, cps as any);
+          const dx = pB.x - pA.x;
+          const dy = pB.y - pA.y;
+          if (Math.abs(dx) > 1e-9 || Math.abs(dy) > 1e-9) {
+            currentHeading = Math.atan2(dy, dx) * (180 / Math.PI);
+          } else {
+            currentHeading = endHeading; // fallback: tangent undefined (cusp), keep full-end heading
+          }
+        } else {
+          // Constant: target heading is fixed regardless of path position
+          currentHeading = endHeading;
+        }
+      } else {
+        currentHeading = endHeading;
+      }
       lastPoint = (constraintEndPoint as Point | undefined) ?? (line.endPoint as Point);
     });
   };

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -833,7 +833,28 @@ export function calculatePathTime(
       const rotationTime =
         (rotationRequired * (Math.PI / 180)) / safeSettings.aVelocity;
 
-      const segmentTime = Math.max(translationTime, rotationTime);
+      let segmentTime = Math.max(translationTime, rotationTime);
+
+      // Apply Constraints to estimated time
+      if (line.constraints) {
+        // T-Value: The robot considers the path complete earlier
+        if (line.constraints.tValue !== undefined) {
+          segmentTime *= line.constraints.tValue;
+        }
+
+        // Velocity: The robot considers the path complete when velocity drops below this value
+        // We save the time it would take to decelerate from this velocity to zero
+        if (line.constraints.velocity !== undefined) {
+          const maxDec = safeSettings.maxDeceleration || safeSettings.maxAcceleration || 30;
+          const timeSaved = line.constraints.velocity / maxDec;
+          segmentTime = Math.max(0.001, segmentTime - timeSaved);
+        }
+
+        // Timeout: The robot waits up to this amount of time at the end to correct
+        if (line.constraints.timeout !== undefined) {
+          segmentTime += line.constraints.timeout / 1000; // ms to seconds
+        }
+      }
 
       segmentTimes.push(segmentTime);
       const lineIndex = contextLines.findIndex((l) => l.id === line.id);


### PR DESCRIPTION
Introduce PathConstraints (timeout, tValue, velocity, translational, heading) and attach them to Line types (src/types/index.ts and plugins/pedro.d.ts). Add a new ConstraintsSection.svelte UI component to edit these constraints and wire it into PathLineSection.svelte. Update code exporters (src/utils/codeExporter.ts) to emit corresponding builder calls (.setTimeoutConstraint, .setTValueConstraint, .setVelocityConstraint, .setTranslationalConstraint, .setHeadingConstraint) when generating Java path code. Adjust time estimation logic (src/utils/timeCalculator.ts) to account for constraints: scale by tValue, reduce estimated time for velocity-based early completion (using max deceleration), and add timeout as wait time. These changes enable specifying per-path completion constraints, exporting them to code, and reflecting them in timing estimates.