### PR TITLE
Add piecewise and global heading control

### DIFF
--- a/plugins/turtle.d.ts
+++ b/plugins/turtle.d.ts
@@ -26,33 +26,33 @@ type PiecewiseSegment = {
       heading: "linear";
       startDeg: number;
       endDeg: number;
-      degrees?: never;
-      targetX?: never;
-      targetY?: never;
+      degrees?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "constant";
       degrees: number;
-      startDeg?: never;
-      endDeg?: never;
-      targetX?: never;
-      targetY?: never;
+      startDeg?: undefined;
+      endDeg?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "tangential";
-      degrees?: never;
-      startDeg?: never;
-      endDeg?: never;
-      targetX?: never;
-      targetY?: never;
+      degrees?: undefined;
+      startDeg?: undefined;
+      endDeg?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "facingPoint";
       targetX: number;
       targetY: number;
-      degrees?: never;
-      startDeg?: never;
-      endDeg?: never;
+      degrees?: undefined;
+      startDeg?: undefined;
+      endDeg?: undefined;
     }
 ) & {
     reverse?: boolean;
@@ -64,46 +64,46 @@ type Point = BasePoint &
         heading: "linear";
         startDeg: number;
         endDeg: number;
-        degrees?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        degrees?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "constant";
         degrees: number;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "tangential";
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "facingPoint";
         targetX: number;
         targetY: number;
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        segments?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "piecewise";
         segments: PiecewiseSegment[];
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
       }
   ) & {
     reverse?: boolean;
@@ -387,6 +387,9 @@ interface TimelineEvent {
   velocityProfile?: number[];
   // Detailed heading profile for travel events: maps step index to unwrapped heading
   headingProfile?: number[];
+  isGlobalOverride?: boolean;
+  rootLine?: Line;
+  globalHeading?: Point["heading"];
 }
 
 interface TimePrediction {

--- a/plugins/turtle.d.ts
+++ b/plugins/turtle.d.ts
@@ -18,6 +18,46 @@ interface BasePoint {
   originalId?: string;
 }
 
+type PiecewiseSegment = {
+  tStart: number;
+  tEnd: number;
+} & (
+  | {
+      heading: "linear";
+      startDeg: number;
+      endDeg: number;
+      degrees?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "constant";
+      degrees: number;
+      startDeg?: never;
+      endDeg?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "tangential";
+      degrees?: never;
+      startDeg?: never;
+      endDeg?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "facingPoint";
+      targetX: number;
+      targetY: number;
+      degrees?: never;
+      startDeg?: never;
+      endDeg?: never;
+    }
+) & {
+    reverse?: boolean;
+  };
+
 type Point = BasePoint &
   (
     | {
@@ -27,6 +67,7 @@ type Point = BasePoint &
         degrees?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "constant";
@@ -35,6 +76,7 @@ type Point = BasePoint &
         endDeg?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "tangential";
@@ -43,6 +85,7 @@ type Point = BasePoint &
         endDeg?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "facingPoint";
@@ -51,6 +94,16 @@ type Point = BasePoint &
         degrees?: never;
         startDeg?: never;
         endDeg?: never;
+        segments?: never;
+      }
+    | {
+        heading: "piecewise";
+        segments: PiecewiseSegment[];
+        degrees?: never;
+        startDeg?: never;
+        endDeg?: never;
+        targetX?: never;
+        targetY?: never;
       }
   ) & {
     reverse?: boolean;
@@ -98,6 +151,14 @@ interface Line {
   macroId?: string;
   originalId?: string;
   isChain?: boolean;
+  globalHeading?: Point["heading"] | "none"; // Used when isChain is true, acts as a global override
+  globalDegrees?: number;
+  globalStartDeg?: number;
+  globalEndDeg?: number;
+  globalTargetX?: number;
+  globalTargetY?: number;
+  globalReverse?: boolean;
+  globalSegments?: PiecewiseSegment[];
 }
 
 type SequencePathItem = {

--- a/src/config/keybindings.ts
+++ b/src/config/keybindings.ts
@@ -239,6 +239,27 @@ export const DEFAULT_KEY_BINDINGS: KeyBinding[] = [
     action: "toggleLock",
     category: "Editing",
   },
+  {
+    id: "toggle-path-chain",
+    key: "shift+k",
+    description: "Toggle Path Chain",
+    action: "togglePathChain",
+    category: "Editing",
+  },
+  {
+    id: "toggle-piecewise",
+    key: "alt+k",
+    description: "Toggle Piecewise Heading",
+    action: "togglePiecewise",
+    category: "Editing",
+  },
+  {
+    id: "toggle-global-heading",
+    key: "shift+g",
+    description: "Toggle Global Chain Heading",
+    action: "toggleGlobalHeading",
+    category: "Editing",
+  },
 
   // Playback
   {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -655,10 +655,22 @@
                 const isPiecewise = parts.length > 2 && parts[2] === "piecewise";
                 const segIdx = isPiecewise ? Number(parts[3]) : -1;
                 
-                // If this line has global heading def, update global values
-                if (line.globalHeading !== undefined) {
+                // Find the effective global source line (always the root of the chain)
+                let rootIdx = lineIdx;
+                if (lines[lineIdx].isChain) {
+                  for (let i = lineIdx; i >= 0; i--) {
+                    if (!lines[i].isChain) {
+                      rootIdx = i;
+                      break;
+                    }
+                  }
+                }
+                const targetLine = lines[rootIdx];
+
+                // If this chain has global heading def, update global values on the root line
+                if (targetLine.globalHeading !== undefined) {
                   if (isPiecewise) {
-                    const segments = line.globalSegments || [];
+                    const segments = targetLine.globalSegments || [];
                     const seg = segments[segIdx];
                     if (seg && seg.heading === "facingPoint") {
                       const newSegs = [...segments] as any[];
@@ -667,19 +679,22 @@
                         targetX: inchX,
                         targetY: inchY,
                       };
-                      lines[lineIdx] = { ...line, globalSegments: newSegs };
+                      lines[rootIdx] = {
+                        ...targetLine,
+                        globalSegments: newSegs,
+                      };
                       linesChanged = true;
                     }
                   } else {
-                    lines[lineIdx] = {
-                      ...line,
+                    lines[rootIdx] = {
+                      ...targetLine,
                       globalTargetX: inchX,
                       globalTargetY: inchY,
                     };
                     linesChanged = true;
                   }
                 } else {
-                  // Fallback to local endpoint if no global heading def
+                  // Fallback to local endpoint if no global heading def anywhere in the chain
                   if (isPiecewise) {
                     const segments = line.endPoint.segments || [];
                     const seg = segments[segIdx];

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -1107,18 +1107,22 @@
             }
           } else if (currentElem.startsWith("targetpoint-")) {
             const parts = currentElem.split("-");
-            const line = Number(parts[1]) - 1;
-            if (lines[line] && lines[line].endPoint) {
+            const lineIdx = Number(parts[1]) - 1;
+            if (lines[lineIdx] && lines[lineIdx].endPoint) {
+              const targetLine = lines[lineIdx];
+              // Check for Global Heading override
+              const isGlobal = targetLine.globalHeading !== undefined && targetLine.globalHeading !== "none";
+              
               if (parts.length > 2 && parts[2] === "piecewise") {
                  const segIdx = Number(parts[3]);
-                 const segments = lines[line].endPoint.segments || [];
+                 const segments = isGlobal ? (targetLine.globalSegments || []) : (targetLine.endPoint.segments || []);
                  if (segments[segIdx]) {
                     objectX = segments[segIdx].targetX || 0;
                     objectY = segments[segIdx].targetY || 0;
                  }
               } else {
-                 objectX = lines[line].endPoint.targetX || 0;
-                 objectY = lines[line].endPoint.targetY || 0;
+                 objectX = (isGlobal ? targetLine.globalTargetX : targetLine.endPoint.targetX) || 0;
+                 objectY = (isGlobal ? targetLine.globalTargetY : targetLine.endPoint.targetY) || 0;
               }
             }
           } else if (currentElem.startsWith("point-")) {
@@ -1153,18 +1157,21 @@
               }
             } else if (id.startsWith("targetpoint-")) {
               const parts = id.split("-");
-              const line = Number(parts[1]) - 1;
-              if (lines[line] && lines[line].endPoint) {
+              const lineIdx = Number(parts[1]) - 1;
+              if (lines[lineIdx] && lines[lineIdx].endPoint) {
+                const targetLine = lines[lineIdx];
+                const isGlobal = targetLine.globalHeading !== undefined && targetLine.globalHeading !== "none";
+                
                 if (parts.length > 2 && parts[2] === "piecewise") {
                    const segIdx = Number(parts[3]);
-                   const segments = lines[line].endPoint.segments || [];
+                   const segments = isGlobal ? (targetLine.globalSegments || []) : (targetLine.endPoint.segments || []);
                    if (segments[segIdx]) {
                       ox = segments[segIdx].targetX || 0;
                       oy = segments[segIdx].targetY || 0;
                    }
                 } else {
-                   ox = lines[line].endPoint.targetX || 0;
-                   oy = lines[line].endPoint.targetY || 0;
+                   ox = (isGlobal ? targetLine.globalTargetX : targetLine.endPoint.targetX) || 0;
+                   oy = (isGlobal ? targetLine.globalTargetY : targetLine.endPoint.targetY) || 0;
                 }
               }
             } else if (id.startsWith("point-")) {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -82,6 +82,7 @@
     getRandomColor,
     updateRobotImageDisplay,
     getLineStartHeading,
+    getInitialTangentialHeading,
   } from "../../utils";
   import { getAlignmentMenuItems } from "../../utils/alignmentMenu";
   import { toUser } from "../../utils/coordinates";
@@ -1854,7 +1855,8 @@
       lines &&
       lines.length > 0
     ) {
-      const derived = getLineStartHeading(lines[0], startPoint);
+      const derived = getLineStartHeading(lines[0], startPoint, lines[0]);
+
       if (
         typeof startPoint.startDeg !== "number" ||
         Math.abs(startPoint.startDeg - derived) > 1e-6

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -649,27 +649,67 @@
               shapesChanged = true;
             } else if (id.startsWith("targetpoint-")) {
               const parts = id.split("-");
-              const line = Number(parts[1]) - 1;
-              if (lines[line] && lines[line].endPoint) {
-                if (parts.length > 2 && parts[2] === "piecewise") {
-                  const segIdx = Number(parts[3]);
-                  const segments = lines[line].endPoint.segments || [];
-                  if (segments[segIdx]) {
-                    const newSegs = [...segments];
-                    newSegs[segIdx] = { ...newSegs[segIdx], targetX: inchX, targetY: inchY };
-                    lines[line] = { ...lines[line], endPoint: { ...lines[line].endPoint, segments: newSegs } as Point };
+              const lineIdx = Number(parts[1]) - 1;
+              const line = lines[lineIdx];
+              if (line && line.endPoint) {
+                const isPiecewise = parts.length > 2 && parts[2] === "piecewise";
+                const segIdx = isPiecewise ? Number(parts[3]) : -1;
+                
+                // If this line has global heading def, update global values
+                if (line.globalHeading !== undefined) {
+                  if (isPiecewise) {
+                    const segments = line.globalSegments || [];
+                    const seg = segments[segIdx];
+                    if (seg && seg.heading === "facingPoint") {
+                      const newSegs = [...segments] as any[];
+                      newSegs[segIdx] = {
+                        ...seg,
+                        targetX: inchX,
+                        targetY: inchY,
+                      };
+                      lines[lineIdx] = { ...line, globalSegments: newSegs };
+                      linesChanged = true;
+                    }
+                  } else {
+                    lines[lineIdx] = {
+                      ...line,
+                      globalTargetX: inchX,
+                      globalTargetY: inchY,
+                    };
                     linesChanged = true;
                   }
                 } else {
-                  lines[line] = {
-                    ...lines[line],
-                    endPoint: {
-                      ...lines[line].endPoint,
-                      targetX: inchX,
-                      targetY: inchY,
-                    } as Point,
-                  };
-                  linesChanged = true;
+                  // Fallback to local endpoint if no global heading def
+                  if (isPiecewise) {
+                    const segments = line.endPoint.segments || [];
+                    const seg = segments[segIdx];
+                    if (seg && seg.heading === "facingPoint") {
+                      const newSegs = [...segments] as any[];
+                      newSegs[segIdx] = {
+                        ...seg,
+                        targetX: inchX,
+                        targetY: inchY,
+                      };
+                      lines[lineIdx] = {
+                        ...line,
+                        endPoint: {
+                          ...line.endPoint,
+                          segments: newSegs,
+                        } as Point,
+                      };
+                      linesChanged = true;
+                    }
+                  } else {
+                    lines[lineIdx] = {
+                      ...line,
+                      endPoint: {
+                        ...line.endPoint,
+                        targetX: inchX,
+                        targetY: inchY,
+                      } as Point,
+                    };
+                    linesChanged = true;
+                  }
                 }
               }
             } else {
@@ -1862,7 +1902,7 @@
 
   // Points (Start, Control, End, Obstacle Vertices)
   let points = $derived(
-    generatePointElements(startPoint, lines, shapes, {
+    generatePointElements(startPoint, lines, shapes, sequence, {
       x,
       y,
       uiLength,

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -648,17 +648,29 @@
               shapes[shapeIdx] = { ...shapes[shapeIdx], vertices: newVertices };
               shapesChanged = true;
             } else if (id.startsWith("targetpoint-")) {
-              const line = Number(id.split("-")[1]) - 1;
+              const parts = id.split("-");
+              const line = Number(parts[1]) - 1;
               if (lines[line] && lines[line].endPoint) {
-                lines[line] = {
-                  ...lines[line],
-                  endPoint: {
-                    ...lines[line].endPoint,
-                    targetX: inchX,
-                    targetY: inchY,
-                  } as Point,
-                };
-                linesChanged = true;
+                if (parts.length > 2 && parts[2] === "piecewise") {
+                  const segIdx = Number(parts[3]);
+                  const segments = lines[line].endPoint.segments || [];
+                  if (segments[segIdx]) {
+                    const newSegs = [...segments];
+                    newSegs[segIdx] = { ...newSegs[segIdx], targetX: inchX, targetY: inchY };
+                    lines[line] = { ...lines[line], endPoint: { ...lines[line].endPoint, segments: newSegs } as Point };
+                    linesChanged = true;
+                  }
+                } else {
+                  lines[line] = {
+                    ...lines[line],
+                    endPoint: {
+                      ...lines[line].endPoint,
+                      targetX: inchX,
+                      targetY: inchY,
+                    } as Point,
+                  };
+                  linesChanged = true;
+                }
               }
             } else {
               const line = Number(id.split("-")[1]) - 1;
@@ -1038,10 +1050,20 @@
               objectY = shapes[shapeIdx].vertices[vertexIdx].y;
             }
           } else if (currentElem.startsWith("targetpoint-")) {
-            const line = Number(currentElem.split("-")[1]) - 1;
+            const parts = currentElem.split("-");
+            const line = Number(parts[1]) - 1;
             if (lines[line] && lines[line].endPoint) {
-              objectX = lines[line].endPoint.targetX || 0;
-              objectY = lines[line].endPoint.targetY || 0;
+              if (parts.length > 2 && parts[2] === "piecewise") {
+                 const segIdx = Number(parts[3]);
+                 const segments = lines[line].endPoint.segments || [];
+                 if (segments[segIdx]) {
+                    objectX = segments[segIdx].targetX || 0;
+                    objectY = segments[segIdx].targetY || 0;
+                 }
+              } else {
+                 objectX = lines[line].endPoint.targetX || 0;
+                 objectY = lines[line].endPoint.targetY || 0;
+              }
             }
           } else if (currentElem.startsWith("point-")) {
             const line = Number(currentElem.split("-")[1]) - 1;
@@ -1074,10 +1096,20 @@
                 oy = shapes[shapeIdx].vertices[vertexIdx].y;
               }
             } else if (id.startsWith("targetpoint-")) {
-              const line = Number(id.split("-")[1]) - 1;
+              const parts = id.split("-");
+              const line = Number(parts[1]) - 1;
               if (lines[line] && lines[line].endPoint) {
-                ox = lines[line].endPoint.targetX || 0;
-                oy = lines[line].endPoint.targetY || 0;
+                if (parts.length > 2 && parts[2] === "piecewise") {
+                   const segIdx = Number(parts[3]);
+                   const segments = lines[line].endPoint.segments || [];
+                   if (segments[segIdx]) {
+                      ox = segments[segIdx].targetX || 0;
+                      oy = segments[segIdx].targetY || 0;
+                   }
+                } else {
+                   ox = lines[line].endPoint.targetX || 0;
+                   oy = lines[line].endPoint.targetY || 0;
+                }
               }
             } else if (id.startsWith("point-")) {
               const line = Number(id.split("-")[1]) - 1;

--- a/src/lib/components/HeadingControls.svelte
+++ b/src/lib/components/HeadingControls.svelte
@@ -120,7 +120,7 @@
     lastSeg.tEnd = midp;
 
     endPoint.segments.push({
-      ...structuredClone(lastSeg),
+      ...$state.snapshot(lastSeg),
       tStart: midp,
       tEnd: originalEnd,
     });

--- a/src/lib/components/HeadingControls.svelte
+++ b/src/lib/components/HeadingControls.svelte
@@ -7,18 +7,31 @@
     ArrowCircleIcon,
     TriangleWarningIcon,
     ArrowRightIcon,
+    ChevronDownIcon,
+    ChevronUpIcon,
+    EllipsisVerticalIcon,
+    TrashIcon
   } from "./icons";
+  import HeadingControls from "./HeadingControls.svelte";
+  import {
+    reorderSequence,
+    getClosestTarget,
+    type DragPosition,
+  } from "../../utils/dragDrop";
+  import { stopPropagation } from "svelte/legacy";
 
   interface Props {
     endPoint: any;
     locked?: boolean;
     tabindex?: number | undefined;
+    nested?: boolean;
   }
 
   let {
     endPoint = $bindable(),
     locked = false,
     tabindex = undefined,
+    nested = false,
   }: Props = $props();
   const dispatch = createEventDispatcher();
 
@@ -83,7 +96,139 @@
     dispatch("change");
     dispatch("commit");
   }
+
+  function updateTransition(i: number, valStr: string) {
+    const val = parseFloat(valStr);
+    if (!isNaN(val)) {
+      endPoint.segments[i].tStart = val;
+      endPoint.segments[i - 1].tEnd = val;
+      dispatch("change");
+    }
+  }
+
+  function removeTransition(i: number) {
+    endPoint.segments[i - 1].tEnd = endPoint.segments[i].tEnd;
+    endPoint.segments.splice(i, 1);
+    dispatch("change");
+    dispatch("commit");
+  }
+
+  function addSegment() {
+    const lastSeg = endPoint.segments[endPoint.segments.length - 1];
+    const midp = (lastSeg.tStart + lastSeg.tEnd) / 2;
+    const originalEnd = lastSeg.tEnd;
+    lastSeg.tEnd = midp;
+
+    endPoint.segments.push({
+      ...structuredClone(lastSeg),
+      tStart: midp,
+      tEnd: originalEnd,
+    });
+    endPoint.segments = [...endPoint.segments];
+    dispatch("change");
+    dispatch("commit");
+  }
+
+  let collapsedSegments: boolean[] = $state([]);
+  let isPiecewiseCollapsed = $state(false);
+
+  // Drag and drop state
+  let draggingIndex: number | null = $state(null);
+  let dragOverIndex: number | null = $state(null);
+  let dragPosition: DragPosition | null = $state(null);
+  let containerRef: HTMLElement | undefined = $state();
+
+  function handleDragStart(e: DragEvent, index: number) {
+    if (locked) {
+      e.preventDefault();
+      return;
+    }
+    draggingIndex = index;
+    if (e.dataTransfer) {
+      e.dataTransfer.effectAllowed = "move";
+    }
+  }
+
+  function handleWindowDragOver(e: DragEvent) {
+    if (draggingIndex === null) return;
+    if (!containerRef) return;
+    e.preventDefault();
+
+    const target = getClosestTarget(e, "div[data-seg-index]", containerRef);
+    if (!target) return;
+
+    const index = parseInt(target.element.getAttribute("data-seg-index") || "");
+    if (isNaN(index)) return;
+
+    if (dragOverIndex !== index || dragPosition !== target.position) {
+      dragOverIndex = index;
+      dragPosition = target.position;
+    }
+  }
+
+  function handleWindowDrop(e: DragEvent) {
+    if (draggingIndex === null) return;
+    e.preventDefault();
+
+    if (
+      dragOverIndex === null ||
+      dragPosition === null ||
+      draggingIndex === dragOverIndex
+    ) {
+      handleDragEnd();
+      return;
+    }
+
+    // Preserve the original tStart/tEnd bounds
+    const oldBounds = endPoint.segments.map((s: any) => ({ tStart: s.tStart, tEnd: s.tEnd }));
+    
+    endPoint.segments = reorderSequence(
+      endPoint.segments,
+      draggingIndex,
+      dragOverIndex,
+      dragPosition
+    );
+
+    // Reapply bounds purely temporally top-to-bottom
+    endPoint.segments.forEach((seg: any, i: number) => {
+       seg.tStart = oldBounds[i].tStart;
+       seg.tEnd = oldBounds[i].tEnd;
+    });
+
+    dispatch("change");
+    dispatch("commit");
+    handleDragEnd();
+  }
+
+  function handleDragEnd() {
+    draggingIndex = null;
+    dragOverIndex = null;
+    dragPosition = null;
+  }
+
+  function moveSegment(index: number, delta: number) {
+    const targetIndex = index + delta;
+    if (targetIndex < 0 || targetIndex >= endPoint.segments.length) return;
+
+    const oldBounds = endPoint.segments.map((s: any) => ({ tStart: s.tStart, tEnd: s.tEnd }));
+    
+    const newSegments = [...endPoint.segments];
+    const temp = newSegments[index];
+    newSegments[index] = newSegments[targetIndex];
+    newSegments[targetIndex] = temp;
+
+    newSegments.forEach((seg: any, i: number) => {
+       seg.tStart = oldBounds[i].tStart;
+       seg.tEnd = oldBounds[i].tEnd;
+    });
+
+    endPoint.segments = newSegments;
+    dispatch("change");
+    dispatch("commit");
+  }
 </script>
+
+<svelte:window ondragover={handleWindowDragOver} ondrop={handleWindowDrop} />
 
 <div class="flex gap-2 w-full">
   <select
@@ -111,6 +256,17 @@
         // Initialize facingPoint coordinates
         if (typeof endPoint.targetX !== "number") endPoint.targetX = 72;
         if (typeof endPoint.targetY !== "number") endPoint.targetY = 72;
+      } else if (val === "piecewise") {
+        if (!endPoint.segments || endPoint.segments.length === 0) {
+          endPoint.segments = [
+            {
+              tStart: 0,
+              tEnd: 1,
+              heading: "tangential",
+              reverse: endPoint.reverse ?? false,
+            },
+          ];
+        }
       }
 
       dispatch("change");
@@ -128,10 +284,13 @@
     <option value="linear">Linear</option>
     <option value="tangential">Tangential</option>
     <option value="facingPoint">Facing Point</option>
+    {#if !nested}
+      <option value="piecewise">Piecewise</option>
+    {/if}
   </select>
 
   <label
-    class="flex items-center justify-center px-2 py-1.5 bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors shrink-0"
+    class="flex items-center justify-center px-2 py-1.5 bg-neutral-50 dark:bg-neutral-900 border border-neutral-200 dark:border-neutral-700 rounded-lg cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors shrink-0 {endPoint.heading === 'piecewise' ? 'hidden' : ''}"
     title="Reverse the direction of the heading interpolation"
   >
     <input
@@ -343,3 +502,131 @@
     </div>
   {/if}
 </div>
+
+{#if endPoint.heading === "piecewise"}
+  <div class="flex items-center mt-3 pl-1 mb-1">
+    <button
+      onclick={() => { isPiecewiseCollapsed = !isPiecewiseCollapsed; }}
+      class="flex items-center gap-1.5 text-xs font-semibold text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 uppercase tracking-wide transition-colors"
+    >
+      <ChevronDownIcon
+        className="size-3.5 transition-transform duration-200 {isPiecewiseCollapsed ? '-rotate-90' : 'rotate-0'}"
+        strokeWidth={2.5}
+      />
+      Piecewise Segments ({endPoint.segments?.length || 0})
+    </button>
+  </div>
+
+  {#if !isPiecewiseCollapsed}
+    <div bind:this={containerRef} class="flex flex-col gap-0 w-full mt-1 pl-3">
+      {#each endPoint.segments || [] as segment, i}
+        <div class="flex items-center -ml-[13px]">
+          <div class="w-2.5 h-2.5 rounded-full bg-purple-500 mr-2 z-10 shrink-0"></div>
+          {#if i === 0}
+            <span class="text-[10px] text-neutral-400 font-bold bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-200 dark:border-neutral-700 select-none">
+              t = 0.00
+            </span>
+          {:else}
+            <div class="flex items-center gap-2 bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-200 dark:border-neutral-700">
+              <span class="text-[10px] text-neutral-500 font-bold select-none">t =</span>
+              <input
+                type="number"
+                step="0.01" min="0" max="1"
+                value={segment.tStart}
+                oninput={(e) => updateTransition(i, e.currentTarget.value)}
+                onblur={() => dispatch("commit")}
+                disabled={locked}
+                class="w-14 px-1 py-0.5 text-xs bg-white dark:bg-neutral-900 border border-neutral-300 dark:border-neutral-600 rounded focus:ring-1 focus:ring-purple-500 outline-none"
+              />
+              {#if !locked}
+                <button 
+                  onclick={() => removeTransition(i)}
+                  class="text-red-500 hover:text-red-700 p-0.5 rounded hover:bg-red-500/10 transition-colors"
+                  title="Remove Transition"
+                >
+                  <TrashIcon className="size-3" />
+                </button>
+              {/if}
+            </div>
+          {/if}
+        </div>
+        
+        <div 
+          class="border-l-2 border-purple-500/30 ml-[-7px] pl-4 py-2 relative"
+          data-seg-index={i}
+          role="listitem"
+          draggable={!locked}
+          ondragstart={(e) => handleDragStart(e, i)}
+          ondragend={handleDragEnd}
+        >
+          <div 
+            class="relative transition-all duration-200 flex items-center gap-2 group"
+            class:border-t-4={dragOverIndex === i && dragPosition === "top"}
+            class:border-b-4={dragOverIndex === i && dragPosition === "bottom"}
+            class:border-purple-500={dragOverIndex === i}
+            class:dark:border-purple-400={dragOverIndex === i}
+            class:opacity-50={draggingIndex === i}
+            class:cursor-move={!locked}
+          >
+            <!-- Drag Handle Column -->
+            {#if !locked}
+              <div class="cursor-grab active:cursor-grabbing text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 shrink-0">
+                <EllipsisVerticalIcon className="size-4" />
+              </div>
+            {/if}
+
+            <div class="flex flex-col items-center bg-white dark:bg-neutral-800 rounded border border-neutral-200 dark:border-neutral-700 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity shrink-0">
+               <button
+                 title={locked ? "Locked" : "Move up"}
+                 onclick={stopPropagation(() => moveSegment(i, -1))}
+                 class="p-0.5 hover:bg-neutral-50 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400 disabled:opacity-30 rounded-t focus:outline-none focus:ring-2 focus:ring-purple-500"
+                 disabled={i === 0 || locked}
+               >
+                 <ChevronUpIcon className="size-3" />
+               </button>
+               <div class="w-full h-px bg-neutral-200 dark:bg-neutral-700" role="presentation"></div>
+               <button
+                 title={locked ? "Locked" : "Move down"}
+                 onclick={stopPropagation(() => moveSegment(i, 1))}
+                 class="p-0.5 hover:bg-neutral-50 dark:hover:bg-neutral-700 text-neutral-500 dark:text-neutral-400 disabled:opacity-30 rounded-b focus:outline-none focus:ring-2 focus:ring-purple-500"
+                 disabled={i === endPoint.segments.length - 1 || locked}
+               >
+                 <ChevronDownIcon className="size-3" />
+               </button>
+            </div>
+
+            <!-- Segment Body -->
+            <div class="flex-1 min-w-0 pr-1 py-1">
+              <HeadingControls
+                bind:endPoint={endPoint.segments[i]}
+                {locked}
+                nested={true}
+                on:change={() => dispatch("change")}
+                on:commit={() => dispatch("commit")}
+              />
+            </div>
+          </div>
+        </div>
+      {/each}
+
+      <div class="flex items-center -ml-[13px] pb-1 mt-1">
+          <div class="w-2.5 h-2.5 rounded-full bg-purple-500 mr-2 z-10 shrink-0"></div>
+          <span class="text-[10px] text-neutral-400 font-bold bg-neutral-100 dark:bg-neutral-800 px-1.5 py-0.5 rounded border border-neutral-200 dark:border-neutral-700 select-none">
+            t = 1.00
+          </span>
+      </div>
+
+      {#if !locked}
+        <div class="ml-4 mt-2">
+          <button
+            class="text-[11px] bg-neutral-100 dark:bg-neutral-800 hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-600 dark:text-neutral-300 px-3 py-1 rounded-full transition-colors font-semibold shadow-sm border border-neutral-200 dark:border-neutral-700 flex items-center gap-1 w-fit"
+            onclick={addSegment}
+          >
+            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"></path></svg>
+            Add Transition
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+{/if}

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -639,7 +639,7 @@
       }
     },
     resetSettings: () => {
-      settingsStore.set(structuredClone(DEFAULT_SETTINGS));
+      settingsStore.set($state.snapshot(DEFAULT_SETTINGS));
     },
     cycleTheme: () => {
       settingsStore.update((s) => {

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -89,6 +89,9 @@
     toggleHeadingMode,
     toggleReverse,
     toggleLock,
+    togglePathChain,
+    togglePiecewise,
+    toggleGlobalHeading,
   } from "./shortcuts/properties";
   import {
     cycleGridSize,
@@ -252,6 +255,9 @@
     toggleHeadingMode: () => toggleHeadingMode(recordChange),
     toggleReverse: () => toggleReverse(recordChange),
     toggleLock: () => toggleLock(recordChange),
+    togglePathChain: () => togglePathChain(recordChange),
+    togglePiecewise: () => togglePiecewise(recordChange),
+    toggleGlobalHeading: () => toggleGlobalHeading(recordChange),
     toggleOnion: () =>
       settingsStore.update((s) => ({
         ...s,

--- a/src/lib/components/WaypointTable.svelte
+++ b/src/lib/components/WaypointTable.svelte
@@ -1002,7 +1002,7 @@
     if (!item) return;
 
     if (item.kind === "wait") {
-      const newItem = structuredClone(item);
+      const newItem = $state.snapshot(item);
       newItem.id = makeId();
       newItem.locked = false; // unlock duplicate?
       // Preserve empty name when duplicating unnamed waits
@@ -1024,7 +1024,7 @@
       const line = lines.find((l) => l.id === (item as any).lineId);
       if (!line) return;
 
-      const newLine = structuredClone(line);
+      const newLine = $state.snapshot(line);
       newLine.id = makeId();
       newLine.locked = false;
       // Preserve empty name when duplicating unnamed paths

--- a/src/lib/components/WaypointTable.svelte
+++ b/src/lib/components/WaypointTable.svelte
@@ -932,13 +932,49 @@
   function toggleChain(seqIndex: number) {
     const item = sequence[seqIndex];
     if (item && item.kind === "path") {
+      const newIsChain = !(item as any).isChain;
+
+      if (!newIsChain) {
+        // Find the root of the former chain
+        let rootIdx = seqIndex;
+        while (
+          rootIdx > 0 &&
+          sequence[rootIdx - 1].kind === "path" &&
+          (sequence[rootIdx] as any).isChain
+        ) {
+          rootIdx--;
+        }
+
+        // Find the end of the former chain
+        let endIdx = seqIndex;
+        while (
+          endIdx + 1 < sequence.length &&
+          sequence[endIdx + 1].kind === "path" &&
+          (sequence[endIdx + 1] as any).isChain
+        ) {
+          endIdx++;
+        }
+
+        // Reset globalHeading for all paths in the former chain island
+        for (let i = rootIdx; i <= endIdx; i++) {
+          const sItem = sequence[i];
+          if (sItem.kind === "path") {
+            const lIdx = lines.findIndex((l) => l.id === (sItem as any).lineId);
+            if (lIdx !== -1 && lines[lIdx].globalHeading !== undefined) {
+              lines[lIdx] = { ...lines[lIdx], globalHeading: undefined };
+            }
+          }
+        }
+      }
+
       const newSeq = [...sequence];
-      newSeq[seqIndex] = { ...item, isChain: !(item as any).isChain };
+      newSeq[seqIndex] = { ...item, isChain: newIsChain };
       sequence = newSeq;
+
       // Also update the line object
       const lineIdx = lines.findIndex((l) => l.id === (item as any).lineId);
       if (lineIdx !== -1) {
-        lines[lineIdx] = { ...lines[lineIdx], isChain: !(item as any).isChain };
+        lines[lineIdx] = { ...lines[lineIdx], isChain: newIsChain };
         lines = [...lines];
       }
       recordChange();

--- a/src/lib/components/dialogs/OptimizationDialog.svelte
+++ b/src/lib/components/dialogs/OptimizationDialog.svelte
@@ -145,7 +145,7 @@
     isStopping = false;
 
     if (settings) {
-      const linesToOptimize = structuredClone(lines).map((l, idx) => {
+      const linesToOptimize = $state.snapshot(lines).map((l, idx) => {
         const id = l.id || `idx-${idx}`;
         if (!selectionState[id]) {
           l.locked = true;
@@ -176,7 +176,7 @@
         currentBestTime = result.bestTime;
 
         if (showPreview && onPreviewChange && result.bestLines) {
-          const previewLines = structuredClone(result.bestLines);
+          const previewLines = $state.snapshot(result.bestLines);
           restoreUnselectedLocks(previewLines);
           onPreviewChange(previewLines);
         }

--- a/src/lib/components/icons/EllipsisVerticalIcon.svelte
+++ b/src/lib/components/icons/EllipsisVerticalIcon.svelte
@@ -1,0 +1,13 @@
+<!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
+<script lang="ts">
+  let { className = "w-4 h-4" }: { className?: string } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24"
+  fill="currentColor"
+  class={className}
+>
+  <path fill-rule="evenodd" d="M12 5.25a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 8.25a1.5 1.5 0 110-3 1.5 1.5 0 010 3zm0 8.25a1.5 1.5 0 110-3 1.5 1.5 0 010 3z" clip-rule="evenodd" />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -108,3 +108,4 @@ export { default as MicrosoftStoreIcon } from "./MicrosoftStoreIcon.svelte";
 export { default as RobotPlaceholderIcon } from "./RobotPlaceholderIcon.svelte";
 export { default as CriticalIcon } from "./CriticalIcon.svelte";
 export { default as DisabledIcon } from "./DisabledIcon.svelte";
+export { default as EllipsisVerticalIcon } from "./EllipsisVerticalIcon.svelte";

--- a/src/lib/components/renderer/FacingLineGenerator.ts
+++ b/src/lib/components/renderer/FacingLineGenerator.ts
@@ -27,7 +27,29 @@ export function generateFacingLineElements(lines: Line[], ctx: RenderContext) {
   if (activeEvent.type !== "travel") return [];
   const activeLine: Line | undefined =
     activeEvent.line ?? lines[activeEvent.lineIndex];
-  if (!activeLine || activeLine.endPoint.heading !== "facingPoint") return [];
+  if (!activeLine || !activeLine.endPoint) return [];
+  if (activeLine.endPoint.heading === "piecewise") {
+    const segments = activeLine.endPoint.segments || [];
+    const t = activeEvent.endTime > activeEvent.startTime 
+           ? (currentSeconds - activeEvent.startTime) / (activeEvent.endTime - activeEvent.startTime) 
+           : 1.0;
+    
+    let activeSeg = null;
+    for (const seg of segments) {
+      if (t >= seg.tStart && t <= seg.tEnd) {
+        activeSeg = seg; break;
+      }
+    }
+    
+    if (activeSeg && activeSeg.heading === "facingPoint") {
+      const targetX = activeSeg.targetX ?? 72;
+      const targetY = activeSeg.targetY ?? 72;
+      const pathColor = activeLine.color || "#60a5fa";
+      return [{ x1: x(robotXY.x), y1: y(robotXY.y), x2: x(targetX), y2: y(targetY), color: pathColor }];
+    }
+  }
+
+  if (activeLine.endPoint.heading !== "facingPoint") return [];
 
   const targetX = (activeLine.endPoint as any).targetX ?? 72;
   const targetY = (activeLine.endPoint as any).targetY ?? 72;

--- a/src/lib/components/renderer/FacingLineGenerator.ts
+++ b/src/lib/components/renderer/FacingLineGenerator.ts
@@ -23,13 +23,18 @@ export function generateFacingLineElements(lines: Line[], ctx: RenderContext) {
       (e: any) => currentSeconds >= e.startTime && currentSeconds <= e.endTime,
     ) ?? timePrediction.timeline[timePrediction.timeline.length - 1];
 
-  // Only render if it's a travel event on a facingPoint segment
+  // Only render if it's a travel event
   if (activeEvent.type !== "travel") return [];
   const activeLine: Line | undefined =
     activeEvent.line ?? lines[activeEvent.lineIndex];
   if (!activeLine || !activeLine.endPoint) return [];
-  if (activeLine.endPoint.heading === "piecewise") {
-    const segments = activeLine.endPoint.segments || [];
+
+  const isGlobal = activeEvent.isGlobalOverride;
+  const rootLine = activeEvent.rootLine;
+  const headingMode = isGlobal ? activeEvent.globalHeading : activeLine.endPoint.heading;
+
+  if (headingMode === "piecewise") {
+    const segments = isGlobal && rootLine ? (rootLine.globalSegments || []) : (activeLine.endPoint.segments || []);
     const t = activeEvent.endTime > activeEvent.startTime 
            ? (currentSeconds - activeEvent.startTime) / (activeEvent.endTime - activeEvent.startTime) 
            : 1.0;
@@ -49,10 +54,16 @@ export function generateFacingLineElements(lines: Line[], ctx: RenderContext) {
     }
   }
 
-  if (activeLine.endPoint.heading !== "facingPoint") return [];
+  if (headingMode !== "facingPoint") return [];
 
-  const targetX = (activeLine.endPoint as any).targetX ?? 72;
-  const targetY = (activeLine.endPoint as any).targetY ?? 72;
+  const targetX = isGlobal && rootLine 
+    ? (rootLine.globalTargetX ?? 72)
+    : ((activeLine.endPoint as any).targetX ?? 72);
+    
+  const targetY = isGlobal && rootLine 
+    ? (rootLine.globalTargetY ?? 72)
+    : ((activeLine.endPoint as any).targetY ?? 72);
+
   const pathColor = activeLine.color || "#60a5fa";
   return [
     {

--- a/src/lib/components/renderer/PointGenerator.ts
+++ b/src/lib/components/renderer/PointGenerator.ts
@@ -97,16 +97,10 @@ export function generatePointElements(
     let segments: any[] | undefined;
 
     if (isGlobalOverride) {
-      // Only the ROOT line shows the global target point
-      if (line.id === rootLine?.id) {
-        headingType = rootLine.globalHeading;
-        targetX = rootLine.globalTargetX;
-        targetY = rootLine.globalTargetY;
-        segments = rootLine.globalSegments;
-      } else {
-        // This line is in a chain but overriden, so it shows NO individual targets
-        headingType = undefined;
-      }
+      headingType = rootLine!.globalHeading;
+      targetX = rootLine!.globalTargetX;
+      targetY = rootLine!.globalTargetY;
+      segments = rootLine!.globalSegments;
     } else {
       // Standard local heading
       headingType = line.endPoint.heading;

--- a/src/lib/components/renderer/PointGenerator.ts
+++ b/src/lib/components/renderer/PointGenerator.ts
@@ -109,6 +109,37 @@ export function generatePointElements(
       pointText.weight = 700;
       pointGroup.add(pointElem, pointText);
       _points.push(pointGroup);
+    } else if (line.endPoint.heading === "piecewise") {
+      const segments = line.endPoint.segments || [];
+      segments.forEach((seg, segIdx) => {
+        if (seg.heading === "facingPoint") {
+          const pathColor = line.color || "#60a5fa";
+          let pointGroup = new Two.Group();
+          pointGroup.id = `targetpoint-${idx + 1}-piecewise-${segIdx}`;
+          let pointElem = new Two.Circle(
+            x(seg.targetX || 72),
+            y(seg.targetY || 72),
+            uiLength(POINT_RADIUS * 0.85),
+          );
+          pointElem.id = `targetpoint-${idx + 1}-piecewise-${segIdx}-background`;
+          pointElem.fill = pathColor;
+          pointElem.noStroke();
+          let pointText = new Two.Text(
+            "T",
+            x(seg.targetX || 72),
+            y(seg.targetY || 72) - uiLength(0.05),
+          );
+          pointText.id = `targetpoint-${idx + 1}-piecewise-${segIdx}-text`;
+          pointText.size = uiLength(1.4);
+          pointText.family = "ui-sans-serif, system-ui, sans-serif";
+          pointText.alignment = "center";
+          pointText.baseline = "middle";
+          pointText.fill = "white";
+          pointText.weight = 700;
+          pointGroup.add(pointElem, pointText);
+          _points.push(pointGroup);
+        }
+      });
     }
   });
 

--- a/src/lib/components/renderer/PointGenerator.ts
+++ b/src/lib/components/renderer/PointGenerator.ts
@@ -1,7 +1,7 @@
-// Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
 import Two from "two.js";
-import type { Line, Point, Shape } from "../../../types";
+import type { Line, Point, Shape, SequenceItem } from "../../../types";
 import { POINT_RADIUS } from "../../../config";
+import { calculateGlobalChainMeta } from "../../../utils/timeCalculator";
 
 interface RenderContext {
   x: d3.ScaleLinear<number, number>;
@@ -14,6 +14,7 @@ export function generatePointElements(
   startPoint: Point,
   lines: Line[],
   shapes: Shape[],
+  sequence: SequenceItem[],
   ctx: RenderContext,
 ) {
   let _points: (
@@ -22,6 +23,8 @@ export function generatePointElements(
   )[] = [];
   const { x, y, uiLength, multiSelectedPointIds } = ctx;
   const multiSelectedSet = new Set(multiSelectedPointIds);
+
+  const chainMeta = calculateGlobalChainMeta(sequence, lines, startPoint);
 
   let startPointElem = new Two.Circle(
     x(startPoint.x),
@@ -83,13 +86,42 @@ export function generatePointElements(
       }
     });
 
-    if (line.endPoint.heading === "facingPoint") {
+    const meta = chainMeta.get(line.id!);
+    const rootLine = meta?.rootLine;
+    const isGlobalOverride = !!(rootLine?.globalHeading && rootLine.globalHeading !== 'none');
+    
+    // Determine which heading info to use for dot rendering
+    let targetX: number | undefined;
+    let targetY: number | undefined;
+    let headingType: string | undefined;
+    let segments: any[] | undefined;
+
+    if (isGlobalOverride) {
+      // Only the ROOT line shows the global target point
+      if (line.id === rootLine?.id) {
+        headingType = rootLine.globalHeading;
+        targetX = rootLine.globalTargetX;
+        targetY = rootLine.globalTargetY;
+        segments = rootLine.globalSegments;
+      } else {
+        // This line is in a chain but overriden, so it shows NO individual targets
+        headingType = undefined;
+      }
+    } else {
+      // Standard local heading
+      headingType = line.endPoint.heading;
+      targetX = (line.endPoint as any).targetX;
+      targetY = (line.endPoint as any).targetY;
+      segments = line.endPoint.segments;
+    }
+
+    if (headingType === "facingPoint") {
       const pathColor = line.color || "#60a5fa";
       let pointGroup = new Two.Group();
       pointGroup.id = `targetpoint-${idx + 1}`;
       let pointElem = new Two.Circle(
-        x((line.endPoint as any).targetX || 72),
-        y((line.endPoint as any).targetY || 72),
+        x(targetX || 72),
+        y(targetY || 72),
         uiLength(POINT_RADIUS * 0.85),
       );
       pointElem.id = `targetpoint-${idx + 1}-background`;
@@ -97,8 +129,8 @@ export function generatePointElements(
       pointElem.noStroke();
       let pointText = new Two.Text(
         "T",
-        x((line.endPoint as any).targetX || 72),
-        y((line.endPoint as any).targetY || 72) - uiLength(0.05),
+        x(targetX || 72),
+        y(targetY || 72) - uiLength(0.05),
       );
       pointText.id = `targetpoint-${idx + 1}-text`;
       pointText.size = uiLength(1.4);
@@ -109,9 +141,9 @@ export function generatePointElements(
       pointText.weight = 700;
       pointGroup.add(pointElem, pointText);
       _points.push(pointGroup);
-    } else if (line.endPoint.heading === "piecewise") {
-      const segments = line.endPoint.segments || [];
-      segments.forEach((seg, segIdx) => {
+    } else if (headingType === "piecewise") {
+      const segs = segments || [];
+      segs.forEach((seg, segIdx) => {
         if (seg.heading === "facingPoint") {
           const pathColor = line.color || "#60a5fa";
           let pointGroup = new Two.Group();

--- a/src/lib/components/sections/ObstaclesSection.svelte
+++ b/src/lib/components/sections/ObstaclesSection.svelte
@@ -94,7 +94,7 @@
     const newPreset: ObstaclePreset = {
       id: `preset-${Math.random().toString(36).slice(2)}`,
       name: name,
-      shapes: structuredClone(shapes), // Deep copy
+      shapes: $state.snapshot(shapes), // Deep copy
     };
 
     $settingsStore.obstaclePresets = [
@@ -117,7 +117,7 @@
       if (!confirm("This will replace current obstacles. Continue?")) return;
     }
 
-    shapes = structuredClone(preset.shapes); // Deep copy
+    shapes = $state.snapshot(preset.shapes); // Deep copy
     // Reset collapsed states
     collapsedObstacles = new Array(shapes.length).fill(false);
     recordChange?.("Load Obstacle Preset");

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -182,11 +182,9 @@
      segments: [] as any[]
   });
 
-  // Track if we are syncing so we don't trigger circular updates
-  let isSyncingToPseudo = false;
+  // Watch STORE -> SIDEBAR (Sync only when store changes externally)
   $effect(() => {
-    // SYNC STORE -> SIDEBAR
-    // Only watch global props
+    // Watch these from the line prop (store)
     const gh = line.globalHeading;
     const gr = line.globalReverse;
     const gd = line.globalDegrees;
@@ -197,22 +195,8 @@
     const gsegs = line.globalSegments;
 
     untrack(() => {
-      if (gh !== undefined && !isSyncingToPseudo) {
-        // Equal check to prevent depth-exceeded
-        const areEqual =
-          pseudoGlobalEndPoint.heading === gh &&
-          pseudoGlobalEndPoint.reverse === (gr ?? false) &&
-          pseudoGlobalEndPoint.degrees === (gd ?? 0) &&
-          pseudoGlobalEndPoint.startDeg === (gsd ?? 0) &&
-          pseudoGlobalEndPoint.endDeg === (ged ?? 0) &&
-          pseudoGlobalEndPoint.targetX === (gtx ?? 72) &&
-          pseudoGlobalEndPoint.targetY === (gty ?? 72) &&
-          JSON.stringify($state.snapshot(pseudoGlobalEndPoint.segments)) ===
-            JSON.stringify(gsegs || []);
-
-        if (areEqual) return;
-
-        isSyncingToPseudo = true;
+      // Apply to our local pseudo-object for the UI
+      if (gh !== undefined) {
         pseudoGlobalEndPoint.heading = gh;
         pseudoGlobalEndPoint.reverse = gr ?? false;
         pseudoGlobalEndPoint.degrees = gd ?? 0;
@@ -220,36 +204,18 @@
         pseudoGlobalEndPoint.endDeg = ged ?? 0;
         pseudoGlobalEndPoint.targetX = gtx ?? 72;
         pseudoGlobalEndPoint.targetY = gty ?? 72;
-        pseudoGlobalEndPoint.segments = (gsegs
-          ? $state.snapshot(gsegs)
-          : []) as any;
-        isSyncingToPseudo = false;
-      }
-    });
-  });
-
-  // Watch pseudo state and sync back to line (SIDEBAR -> STORE)
-  $effect(() => {
-    // Manually track pseudo props
-    pseudoGlobalEndPoint.heading;
-    pseudoGlobalEndPoint.reverse;
-    pseudoGlobalEndPoint.degrees;
-    pseudoGlobalEndPoint.startDeg;
-    pseudoGlobalEndPoint.endDeg;
-    pseudoGlobalEndPoint.targetX;
-    pseudoGlobalEndPoint.targetY;
-    pseudoGlobalEndPoint.segments;
-
-    untrack(() => {
-      if (!isSyncingToPseudo && line.globalHeading !== undefined) {
-        handleGlobalChange();
+        
+        // Initialize segments if Piecewise is active but list is empty
+        let nextSegs = gsegs ? $state.snapshot(gsegs) : [];
+        if (gh === "piecewise" && nextSegs.length === 0) {
+          nextSegs = [{ tStart: 0, tEnd: 1, heading: "tangential", reverse: gr ?? false }];
+        }
+        pseudoGlobalEndPoint.segments = nextSegs;
       }
     });
   });
 
   function handleGlobalChange() {
-    if (isSyncingToPseudo) return;
-
     const targetIdx = chainRootIndex !== -1 ? chainRootIndex : idx;
     const targetLine = lines[targetIdx];
 
@@ -639,10 +605,13 @@
                       targetLine.globalStartDeg = line.endPoint.startDeg;
                     if (line.endPoint.endDeg !== undefined)
                       targetLine.globalEndDeg = line.endPoint.endDeg;
-                    if (line.endPoint.segments !== undefined)
+                    if (line.endPoint.segments && line.endPoint.segments.length > 0)
                       targetLine.globalSegments = $state.snapshot(
                         line.endPoint.segments,
                       );
+                    else if (line.endPoint.heading === "piecewise") {
+                      targetLine.globalSegments = [{ tStart: 0, tEnd: 1, heading: "tangential", reverse: line.endPoint.reverse ?? false }];
+                    }
                   } else {
                     targetLine.globalHeading = undefined;
                   }
@@ -680,7 +649,7 @@
             {#if hasGlobalHeadingDef}
               <div class="pl-2 mt-2 ml-1 border-l-2 border-purple-500/30">
                  <HeadingControls
-                    bind:endPoint={pseudoGlobalEndPoint}
+                    endPoint={pseudoGlobalEndPoint}
                     locked={line.locked}
                     on:change={handleGlobalChange}
                     on:commit={() => {

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -14,6 +14,7 @@
     selectedPointId,
     focusRequest,
   } from "../../../stores";
+  import { startPointStore } from "../../projectStore";
   import DeleteButtonWithConfirm from "../common/DeleteButtonWithConfirm.svelte";
   import {
     handleWaypointRename,
@@ -247,17 +248,44 @@
   });
 
   function handleGlobalChange() {
-     if (isSyncingToPseudo) return;
-     line.globalHeading = pseudoGlobalEndPoint.heading as any;
-     line.globalReverse = pseudoGlobalEndPoint.reverse;
-     line.globalDegrees = pseudoGlobalEndPoint.degrees;
-     line.globalStartDeg = pseudoGlobalEndPoint.startDeg;
-     line.globalEndDeg = pseudoGlobalEndPoint.endDeg;
-     line.globalTargetX = pseudoGlobalEndPoint.targetX;
-     line.globalTargetY = pseudoGlobalEndPoint.targetY;
-     line.globalSegments = $state.snapshot(pseudoGlobalEndPoint.segments);
-     lines[idx] = {...line};
-     lines = [...lines];
+    if (isSyncingToPseudo) return;
+
+    const targetIdx = chainRootIndex !== -1 ? chainRootIndex : idx;
+    const targetLine = lines[targetIdx];
+
+    targetLine.globalHeading = pseudoGlobalEndPoint.heading as any;
+    targetLine.globalReverse = pseudoGlobalEndPoint.reverse;
+    targetLine.globalDegrees = pseudoGlobalEndPoint.degrees;
+    targetLine.globalStartDeg = pseudoGlobalEndPoint.startDeg;
+    targetLine.globalEndDeg = pseudoGlobalEndPoint.endDeg;
+    targetLine.globalTargetX = pseudoGlobalEndPoint.targetX;
+    targetLine.globalTargetY = pseudoGlobalEndPoint.targetY;
+    targetLine.globalSegments = $state.snapshot(pseudoGlobalEndPoint.segments);
+
+    lines[targetIdx] = { ...targetLine };
+    lines = [...lines];
+
+    // If this is the first path in the project, sync the project start point heading
+    if (targetIdx === 0) {
+      startPointStore.update((s) => {
+        const h = pseudoGlobalEndPoint.heading;
+        if (h === "constant" || h === "linear") {
+          s.heading = h;
+          if (h === "constant") s.degrees = pseudoGlobalEndPoint.degrees;
+          else {
+            s.startDeg = pseudoGlobalEndPoint.startDeg;
+            s.endDeg = pseudoGlobalEndPoint.endDeg;
+          }
+        } else if (h === "tangential" || h === "facingPoint") {
+          s.heading = h;
+          if (h === "facingPoint") {
+            s.targetX = pseudoGlobalEndPoint.targetX;
+            s.targetY = pseudoGlobalEndPoint.targetY;
+          }
+        }
+        return { ...s };
+      });
+    }
   }
 
   function handleLinkHoverEnter(e: MouseEvent, id: string | null) {
@@ -594,21 +622,54 @@
                 type="checkbox" 
                 checked={hasGlobalHeadingDef}
                 onchange={(e) => {
+                  const targetIdx =
+                    chainRootIndex !== -1 ? chainRootIndex : idx;
+                  const targetLine = lines[targetIdx];
                   if (e.currentTarget.checked) {
-                     line.globalHeading = line.endPoint.heading;
-                     if (line.endPoint.degrees !== undefined) line.globalDegrees = line.endPoint.degrees;
-                     if (line.endPoint.targetX !== undefined) line.globalTargetX = line.endPoint.targetX;
-                     if (line.endPoint.targetY !== undefined) line.globalTargetY = line.endPoint.targetY;
-                     if (line.endPoint.reverse !== undefined) line.globalReverse = line.endPoint.reverse;
-                     if (line.endPoint.startDeg !== undefined) line.globalStartDeg = line.endPoint.startDeg;
-                     if (line.endPoint.endDeg !== undefined) line.globalEndDeg = line.endPoint.endDeg;
-                     if (line.endPoint.segments !== undefined) line.globalSegments = $state.snapshot(line.endPoint.segments);
+                    targetLine.globalHeading = line.endPoint.heading;
+                    if (line.endPoint.degrees !== undefined)
+                      targetLine.globalDegrees = line.endPoint.degrees;
+                    if (line.endPoint.targetX !== undefined)
+                      targetLine.globalTargetX = line.endPoint.targetX;
+                    if (line.endPoint.targetY !== undefined)
+                      targetLine.globalTargetY = line.endPoint.targetY;
+                    if (line.endPoint.reverse !== undefined)
+                      targetLine.globalReverse = line.endPoint.reverse;
+                    if (line.endPoint.startDeg !== undefined)
+                      targetLine.globalStartDeg = line.endPoint.startDeg;
+                    if (line.endPoint.endDeg !== undefined)
+                      targetLine.globalEndDeg = line.endPoint.endDeg;
+                    if (line.endPoint.segments !== undefined)
+                      targetLine.globalSegments = $state.snapshot(
+                        line.endPoint.segments,
+                      );
                   } else {
-                     line.globalHeading = undefined;
+                    targetLine.globalHeading = undefined;
                   }
-                  lines[idx] = {...line};
+                  if (targetIdx === 0) {
+                    startPointStore.update((s) => {
+                      const h = targetLine.globalHeading;
+                      if (h === "constant" || h === "linear") {
+                        s.heading = h;
+                        if (h === "constant")
+                          s.degrees = targetLine.globalDegrees || 0;
+                        else {
+                          s.startDeg = targetLine.globalStartDeg || 0;
+                          s.endDeg = targetLine.globalEndDeg || 0;
+                        }
+                      } else if (h === "tangential" || h === "facingPoint") {
+                        s.heading = h;
+                        if (h === "facingPoint") {
+                          s.targetX = targetLine.globalTargetX || 0;
+                          s.targetY = targetLine.globalTargetY || 0;
+                        }
+                      }
+                      return { ...s };
+                    });
+                  }
+                  lines[targetIdx] = { ...targetLine };
                   lines = [...lines];
-                  if(recordChange) recordChange("Toggle Global Heading");
+                  if (recordChange) recordChange("Toggle Global Heading");
                 }}
                 disabled={line.locked}
                 class="rounded text-purple-500 focus:ring-purple-500 bg-neutral-100 dark:bg-neutral-900 border-neutral-300 dark:border-neutral-700"

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -137,6 +137,76 @@
     }
   });
 
+  let isChainContinuation = $derived(line.isChain ?? false);
+  let isChainRoot = $derived(!isChainContinuation && idx + 1 < lines.length && lines[idx + 1].isChain);
+  
+  let chainRootIndex = $derived.by(() => {
+    if (isChainRoot) return idx;
+    if (isChainContinuation) {
+      for (let i = idx; i >= 0; i--) {
+        if (!lines[i].isChain) return i;
+      }
+    }
+    return -1;
+  });
+
+  let chainGlobalSourceLine = $derived.by(() => {
+    if (chainRootIndex === -1) return null;
+    if (lines[chainRootIndex].globalHeading !== undefined) return lines[chainRootIndex];
+    for (let i = chainRootIndex + 1; i < lines.length; i++) {
+        if (!lines[i].isChain) break;
+        if (lines[i].globalHeading !== undefined) return lines[i];
+    }
+    return null;
+  });
+
+  let isPartOfChain = $derived(isChainRoot || isChainContinuation);
+  let hasGlobalHeadingDef = $derived(line.globalHeading !== undefined);
+  let isOverriddenByGlobalHeading = $derived(chainGlobalSourceLine !== null && chainGlobalSourceLine !== line);
+  let canShowGlobalHeadingToggle = $derived(isPartOfChain && !isOverriddenByGlobalHeading);
+
+  let pseudoGlobalEndPoint = $state({
+     heading: "tangential",
+     reverse: false,
+     degrees: 0,
+     startDeg: 0,
+     endDeg: 0,
+     targetX: 72,
+     targetY: 72,
+     segments: [] as any[]
+  });
+
+  // Track if we are syncing so we don't trigger circular updates
+  let isSyncingToPseudo = false;
+  $effect(() => {
+     if (line.globalHeading) {
+        isSyncingToPseudo = true;
+        pseudoGlobalEndPoint.heading = line.globalHeading;
+        pseudoGlobalEndPoint.reverse = line.globalReverse ?? false;
+        pseudoGlobalEndPoint.degrees = line.globalDegrees ?? 0;
+        pseudoGlobalEndPoint.startDeg = line.globalStartDeg ?? 0;
+        pseudoGlobalEndPoint.endDeg = line.globalEndDeg ?? 0;
+        pseudoGlobalEndPoint.targetX = line.globalTargetX ?? 72;
+        pseudoGlobalEndPoint.targetY = line.globalTargetY ?? 72;
+        pseudoGlobalEndPoint.segments = (line.globalSegments ? structuredClone(line.globalSegments) : []);
+        isSyncingToPseudo = false;
+     }
+  });
+
+  function handleGlobalChange() {
+     if (isSyncingToPseudo) return;
+     line.globalHeading = pseudoGlobalEndPoint.heading as any;
+     line.globalReverse = pseudoGlobalEndPoint.reverse;
+     line.globalDegrees = pseudoGlobalEndPoint.degrees;
+     line.globalStartDeg = pseudoGlobalEndPoint.startDeg;
+     line.globalEndDeg = pseudoGlobalEndPoint.endDeg;
+     line.globalTargetX = pseudoGlobalEndPoint.targetX;
+     line.globalTargetY = pseudoGlobalEndPoint.targetY;
+     line.globalSegments = structuredClone(pseudoGlobalEndPoint.segments);
+     lines[idx] = {...line};
+     lines = [...lines];
+  }
+
   function handleLinkHoverEnter(e: MouseEvent, id: string | null) {
     hoveredLinkId = id;
     hoveredLinkAnchor = e.currentTarget as HTMLElement;
@@ -428,27 +498,86 @@
         </div>
 
         <!-- Heading Control -->
-        <div class="space-y-2" class:col-span-2={!isNarrow}>
-          <span
-            class="text-xs font-semibold text-neutral-500 uppercase tracking-wide block"
+        {#if !isOverriddenByGlobalHeading && !hasGlobalHeadingDef}
+          <div 
+            class="space-y-2" 
+            class:col-span-2={!isNarrow && line.endPoint.heading !== "piecewise"}
+            class:col-span-3={!isNarrow && line.endPoint.heading === "piecewise"}
           >
-            Heading
-          </span>
-          <HeadingControls
-            bind:this={headingControls}
-            endPoint={line.endPoint}
-            locked={line.locked}
-            on:change={() => {
-              lines[idx] = { ...line, endPoint: { ...line.endPoint } };
-              lines = [...lines];
-            }}
-            on:commit={() => {
-              lines[idx] = { ...line, endPoint: { ...line.endPoint } };
-              lines = [...lines];
-              recordChange("Update Heading");
-            }}
-          />
-        </div>
+            <span
+              class="text-xs font-semibold text-neutral-500 uppercase tracking-wide block"
+            >
+              Heading
+            </span>
+            <HeadingControls
+              bind:this={headingControls}
+              endPoint={line.endPoint}
+              locked={line.locked}
+              on:change={() => {
+                lines[idx] = { ...line, endPoint: { ...line.endPoint } };
+                lines = [...lines];
+              }}
+              on:commit={() => {
+                lines[idx] = { ...line, endPoint: { ...line.endPoint } };
+                lines = [...lines];
+                if (recordChange) recordChange("Update Heading");
+              }}
+            />
+          </div>
+        {:else}
+          <div class="space-y-2" class:col-span-2={!isNarrow}>
+            <span class="text-xs font-semibold text-neutral-500 uppercase tracking-wide block">Heading</span>
+            <div class="text-sm text-neutral-400 p-2 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 rounded-lg flex items-center gap-2">
+              <LinkIcon className="size-4 shrink-0 text-purple-500" />
+              Overridden by Global Chain Heading
+            </div>
+          </div>
+        {/if}
+
+        {#if canShowGlobalHeadingToggle}
+          <div class="space-y-2 col-span-1 border-t border-neutral-100 dark:border-neutral-700 pt-2" class:col-span-3={!isNarrow}>
+            <label class="flex items-center gap-2 cursor-pointer w-fit">
+              <input 
+                type="checkbox" 
+                checked={hasGlobalHeadingDef}
+                onchange={(e) => {
+                  if (e.currentTarget.checked) {
+                     line.globalHeading = line.endPoint.heading;
+                     if (line.endPoint.degrees !== undefined) line.globalDegrees = line.endPoint.degrees;
+                     if (line.endPoint.targetX !== undefined) line.globalTargetX = line.endPoint.targetX;
+                     if (line.endPoint.targetY !== undefined) line.globalTargetY = line.endPoint.targetY;
+                     if (line.endPoint.reverse !== undefined) line.globalReverse = line.endPoint.reverse;
+                     if (line.endPoint.startDeg !== undefined) line.globalStartDeg = line.endPoint.startDeg;
+                     if (line.endPoint.endDeg !== undefined) line.globalEndDeg = line.endPoint.endDeg;
+                     if (line.endPoint.segments !== undefined) line.globalSegments = structuredClone(line.endPoint.segments);
+                  } else {
+                     line.globalHeading = undefined;
+                  }
+                  lines[idx] = {...line};
+                  lines = [...lines];
+                  if(recordChange) recordChange("Toggle Global Heading");
+                }}
+                disabled={line.locked}
+                class="rounded text-purple-500 focus:ring-purple-500 bg-neutral-100 dark:bg-neutral-900 border-neutral-300 dark:border-neutral-700"
+              />
+              <span class="text-sm font-semibold text-neutral-600 dark:text-neutral-300">Global Chain Heading</span>
+            </label>
+
+            {#if hasGlobalHeadingDef}
+              <div class="pl-2 mt-2 ml-1 border-l-2 border-purple-500/30">
+                 <HeadingControls
+                    bind:endPoint={pseudoGlobalEndPoint}
+                    locked={line.locked}
+                    on:change={handleGlobalChange}
+                    on:commit={() => {
+                      handleGlobalChange();
+                      if (recordChange) recordChange("Update Global Heading");
+                    }}
+                 />
+              </div>
+            {/if}
+          </div>
+        {/if}
       </div>
 
       <ControlPointsSection

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -1,5 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
+  import { untrack } from "svelte";
   import { run, stopPropagation, createBubbler } from "svelte/legacy";
 
   const bubble = createBubbler();
@@ -137,8 +138,12 @@
     }
   });
 
-  let isChainContinuation = $derived(line.isChain ?? false);
-  let isChainRoot = $derived(!isChainContinuation && idx + 1 < lines.length && lines[idx + 1].isChain);
+  let isChainContinuation = $derived(line.isChain === true);
+  let isChainRoot = $derived(
+    !isChainContinuation &&
+      idx + 1 < lines.length &&
+      lines[idx + 1].isChain === true,
+  );
   
   let chainRootIndex = $derived.by(() => {
     if (isChainRoot) return idx;
@@ -179,18 +184,66 @@
   // Track if we are syncing so we don't trigger circular updates
   let isSyncingToPseudo = false;
   $effect(() => {
-     if (line.globalHeading) {
+    // SYNC STORE -> SIDEBAR
+    // Only watch global props
+    const gh = line.globalHeading;
+    const gr = line.globalReverse;
+    const gd = line.globalDegrees;
+    const gsd = line.globalStartDeg;
+    const ged = line.globalEndDeg;
+    const gtx = line.globalTargetX;
+    const gty = line.globalTargetY;
+    const gsegs = line.globalSegments;
+
+    untrack(() => {
+      if (gh !== undefined && !isSyncingToPseudo) {
+        // Equal check to prevent depth-exceeded
+        const areEqual =
+          pseudoGlobalEndPoint.heading === gh &&
+          pseudoGlobalEndPoint.reverse === (gr ?? false) &&
+          pseudoGlobalEndPoint.degrees === (gd ?? 0) &&
+          pseudoGlobalEndPoint.startDeg === (gsd ?? 0) &&
+          pseudoGlobalEndPoint.endDeg === (ged ?? 0) &&
+          pseudoGlobalEndPoint.targetX === (gtx ?? 72) &&
+          pseudoGlobalEndPoint.targetY === (gty ?? 72) &&
+          JSON.stringify($state.snapshot(pseudoGlobalEndPoint.segments)) ===
+            JSON.stringify(gsegs || []);
+
+        if (areEqual) return;
+
         isSyncingToPseudo = true;
-        pseudoGlobalEndPoint.heading = line.globalHeading;
-        pseudoGlobalEndPoint.reverse = line.globalReverse ?? false;
-        pseudoGlobalEndPoint.degrees = line.globalDegrees ?? 0;
-        pseudoGlobalEndPoint.startDeg = line.globalStartDeg ?? 0;
-        pseudoGlobalEndPoint.endDeg = line.globalEndDeg ?? 0;
-        pseudoGlobalEndPoint.targetX = line.globalTargetX ?? 72;
-        pseudoGlobalEndPoint.targetY = line.globalTargetY ?? 72;
-        pseudoGlobalEndPoint.segments = (line.globalSegments ? structuredClone(line.globalSegments) : []);
+        pseudoGlobalEndPoint.heading = gh;
+        pseudoGlobalEndPoint.reverse = gr ?? false;
+        pseudoGlobalEndPoint.degrees = gd ?? 0;
+        pseudoGlobalEndPoint.startDeg = gsd ?? 0;
+        pseudoGlobalEndPoint.endDeg = ged ?? 0;
+        pseudoGlobalEndPoint.targetX = gtx ?? 72;
+        pseudoGlobalEndPoint.targetY = gty ?? 72;
+        pseudoGlobalEndPoint.segments = (gsegs
+          ? $state.snapshot(gsegs)
+          : []) as any;
         isSyncingToPseudo = false;
-     }
+      }
+    });
+  });
+
+  // Watch pseudo state and sync back to line (SIDEBAR -> STORE)
+  $effect(() => {
+    // Manually track pseudo props
+    pseudoGlobalEndPoint.heading;
+    pseudoGlobalEndPoint.reverse;
+    pseudoGlobalEndPoint.degrees;
+    pseudoGlobalEndPoint.startDeg;
+    pseudoGlobalEndPoint.endDeg;
+    pseudoGlobalEndPoint.targetX;
+    pseudoGlobalEndPoint.targetY;
+    pseudoGlobalEndPoint.segments;
+
+    untrack(() => {
+      if (!isSyncingToPseudo && line.globalHeading !== undefined) {
+        handleGlobalChange();
+      }
+    });
   });
 
   function handleGlobalChange() {
@@ -202,7 +255,7 @@
      line.globalEndDeg = pseudoGlobalEndPoint.endDeg;
      line.globalTargetX = pseudoGlobalEndPoint.targetX;
      line.globalTargetY = pseudoGlobalEndPoint.targetY;
-     line.globalSegments = structuredClone(pseudoGlobalEndPoint.segments);
+     line.globalSegments = $state.snapshot(pseudoGlobalEndPoint.segments);
      lines[idx] = {...line};
      lines = [...lines];
   }
@@ -549,7 +602,7 @@
                      if (line.endPoint.reverse !== undefined) line.globalReverse = line.endPoint.reverse;
                      if (line.endPoint.startDeg !== undefined) line.globalStartDeg = line.endPoint.startDeg;
                      if (line.endPoint.endDeg !== undefined) line.globalEndDeg = line.endPoint.endDeg;
-                     if (line.endPoint.segments !== undefined) line.globalSegments = structuredClone(line.endPoint.segments);
+                     if (line.endPoint.segments !== undefined) line.globalSegments = $state.snapshot(line.endPoint.segments);
                   } else {
                      line.globalHeading = undefined;
                   }

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -59,6 +59,7 @@
     onMoveDown: () => void;
     canMoveUp?: boolean;
     canMoveDown?: boolean;
+    onScrollToItem?: (id: string) => void;
   }
 
   let {
@@ -77,6 +78,7 @@
     onMoveDown,
     canMoveUp = true,
     canMoveDown = true,
+    onScrollToItem,
   }: Props = $props();
 
   let isSelected = $derived($selectedLineId === line.id);
@@ -574,10 +576,18 @@
         {:else}
           <div class="space-y-2" class:col-span-2={!isNarrow}>
             <span class="text-xs font-semibold text-neutral-500 uppercase tracking-wide block">Heading</span>
-            <div class="text-sm text-neutral-400 p-2 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 rounded-lg flex items-center gap-2">
+            <button 
+              class="w-full text-left text-sm text-neutral-400 p-2 bg-neutral-50 dark:bg-neutral-800/50 border border-neutral-200 dark:border-neutral-700/50 rounded-lg flex items-center gap-2 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
+              onclick={() => {
+                if (onScrollToItem && chainGlobalSourceLine?.id) {
+                  onScrollToItem(chainGlobalSourceLine.id);
+                }
+              }}
+              title="Jump to global source"
+            >
               <LinkIcon className="size-4 shrink-0 text-purple-500" />
               Overridden by Global Chain Heading
-            </div>
+            </button>
           </div>
         {/if}
 

--- a/src/lib/components/shortcuts/clipboard.ts
+++ b/src/lib/components/shortcuts/clipboard.ts
@@ -64,7 +64,7 @@ export function duplicate(recordChange: (action?: string) => void) {
     ) as any;
     if (!waitItem) return;
 
-    const newWait = structuredClone(waitItem);
+    const newWait = JSON.parse(JSON.stringify(waitItem));
     newWait.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     const existingWaitNames = sequence
@@ -97,7 +97,7 @@ export function duplicate(recordChange: (action?: string) => void) {
     ) as any;
     if (!rotateItem) return;
 
-    const newRotate = structuredClone(rotateItem);
+    const newRotate = JSON.parse(JSON.stringify(rotateItem));
     newRotate.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
     const existingRotateNames = sequence
       .filter((s) => actionRegistry.get(s.kind)?.isRotate)
@@ -148,7 +148,7 @@ export function duplicate(recordChange: (action?: string) => void) {
     const deltaX = originalLine.endPoint.x - prevPoint.x;
     const deltaY = originalLine.endPoint.y - prevPoint.y;
 
-    const newLine = structuredClone(originalLine);
+    const newLine = JSON.parse(JSON.stringify(originalLine));
     newLine.id = `line-${Math.random().toString(36).slice(2)}`;
 
     // Update name (preserve empty name if original was unnamed)
@@ -231,7 +231,7 @@ export function copy(activeControlTab: string, controlTabRef: any) {
       (s) => actionRegistry.get(s.kind)?.isWait && (s as any).id === waitId,
     ) as any;
     if (waitItem) {
-      clipboard = structuredClone(waitItem);
+      clipboard = JSON.parse(JSON.stringify(waitItem));
     }
     return;
   }
@@ -242,7 +242,7 @@ export function copy(activeControlTab: string, controlTabRef: any) {
       (s) => actionRegistry.get(s.kind)?.isRotate && (s as any).id === rotateId,
     ) as any;
     if (rotateItem) {
-      clipboard = structuredClone(rotateItem);
+      clipboard = JSON.parse(JSON.stringify(rotateItem));
     }
     return;
   }
@@ -260,7 +260,7 @@ export function copy(activeControlTab: string, controlTabRef: any) {
   if (targetLineId) {
     const line = lines.find((l) => l.id === targetLineId);
     if (line) {
-      clipboard = structuredClone(line);
+      clipboard = JSON.parse(JSON.stringify(line));
     }
   }
 
@@ -302,7 +302,7 @@ export function paste(recordChange: (action?: string) => void) {
   // Handle Wait
   if (clipDef?.isWait) {
     const waitItem = clipboard as SequenceItem;
-    const newWait = structuredClone(waitItem) as any;
+    const newWait = JSON.parse(JSON.stringify(waitItem)) as any;
     newWait.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Generate unique name
@@ -338,7 +338,7 @@ export function paste(recordChange: (action?: string) => void) {
   // Handle Rotate
   if (clipDef?.isRotate) {
     const rotateItem = clipboard as SequenceItem;
-    const newRotate = structuredClone(rotateItem) as any;
+    const newRotate = JSON.parse(JSON.stringify(rotateItem)) as any;
     newRotate.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     // Generate unique name
@@ -400,7 +400,7 @@ export function paste(recordChange: (action?: string) => void) {
 
     // Clone originalLine; the placement above accounts for insertion index.
 
-    const newLine = structuredClone(originalLine);
+    const newLine = JSON.parse(JSON.stringify(originalLine));
     newLine.id = `line-${Math.random().toString(36).slice(2)}`;
 
     const existingLineNames = lines.map((l) => l.name || "");

--- a/src/lib/components/shortcuts/properties.ts
+++ b/src/lib/components/shortcuts/properties.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
 import { get } from "svelte/store";
 import { linesStore, sequenceStore, startPointStore } from "../../projectStore";
-import { selectedLineId, selectedPointId } from "../../../stores";
+import { selectedLineId, selectedPointId, notification } from "../../../stores";
 import { actionRegistry } from "../../actionRegistry";
 import {
   updateLinkedWaits,
@@ -376,4 +376,204 @@ export function toggleLock(recordChange: (action?: string) => void) {
     });
     recordChange("Toggle Lock");
   }
+}
+
+export function togglePathChain(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
+  const selId = get(selectedLineId);
+  if (!selId) return;
+
+  const sequence = [...get(sequenceStore)];
+  const lines = [...get(linesStore)];
+  const sIdx = sequence.findIndex((s) => s.kind === "path" && s.lineId === selId);
+  if (sIdx === -1 || sIdx === 0) return; // Cannot chain the first path
+
+  const item = sequence[sIdx] as any;
+  const newIsChain = !item.isChain;
+
+  if (!newIsChain) {
+    // Reset globalHeading for all paths in the former chain island
+    let rootIdx = sIdx;
+    while (
+      rootIdx > 0 &&
+      sequence[rootIdx - 1].kind === "path" &&
+      (sequence[rootIdx] as any).isChain
+    ) {
+      rootIdx--;
+    }
+
+    let endIdx = sIdx;
+    while (
+      endIdx + 1 < sequence.length &&
+      sequence[endIdx + 1].kind === "path" &&
+      (sequence[endIdx + 1] as any).isChain
+    ) {
+      endIdx++;
+    }
+
+    for (let i = rootIdx; i <= endIdx; i++) {
+      const sItem = sequence[i];
+      if (sItem.kind === "path") {
+        const lIdx = lines.findIndex((l) => l.id === (sItem as any).lineId);
+        if (lIdx !== -1 && lines[lIdx].globalHeading !== undefined) {
+          lines[lIdx] = { ...lines[lIdx], globalHeading: undefined };
+        }
+      }
+    }
+  }
+
+  sequence[sIdx] = { ...item, isChain: newIsChain };
+  const lIdx = lines.findIndex((l) => l.id === selId);
+  if (lIdx !== -1) {
+    lines[lIdx] = { ...lines[lIdx], isChain: newIsChain };
+  }
+
+  linesStore.set([...lines]);
+  sequenceStore.set([...sequence]);
+  recordChange("Toggle Path Chain");
+
+  notification.set({
+    message: `Path chain ${newIsChain ? "enabled" : "disabled"}`,
+    type: "success",
+    timeout: 2000,
+  });
+}
+
+export function togglePiecewise(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
+  const sel = get(selectedPointId);
+  if (!sel || !sel.startsWith("point-")) return;
+
+  const lines = [...get(linesStore)];
+  const parts = sel.split("-");
+  const lineNum = Number(parts[1]);
+  const ptIdx = Number(parts[2]);
+
+  if (lineNum > 0 && ptIdx === 0) {
+    const lineIndex = lineNum - 1;
+    const line = lines[lineIndex];
+    if (!line || line.locked) return;
+
+    const isPiecewise = line.endPoint.heading === "piecewise";
+    if (isPiecewise) {
+      // Toggle back to tangential
+      lines[lineIndex] = {
+        ...line,
+        endPoint: {
+          ...line.endPoint,
+          heading: "tangential",
+          reverse: false,
+          segments: undefined,
+        } as unknown as Point,
+      };
+    } else {
+      // Toggle to piecewise
+      lines[lineIndex] = {
+        ...line,
+        endPoint: {
+          ...line.endPoint,
+          heading: "piecewise",
+          segments: [
+            { tStart: 0, tEnd: 1, heading: "tangential", reverse: line.endPoint.reverse ?? false },
+          ],
+        } as unknown as Point,
+      };
+    }
+    linesStore.set(lines);
+    recordChange("Toggle Piecewise Heading");
+
+    notification.set({
+      message: `Piecewise heading ${!isPiecewise ? "enabled" : "disabled"}`,
+      type: "success",
+      timeout: 2000,
+    });
+  }
+}
+
+export function toggleGlobalHeading(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
+  const selId = get(selectedLineId);
+  if (!selId) return;
+
+  const lines = [...get(linesStore)];
+  const sequence = get(sequenceStore);
+  const idx = lines.findIndex((l) => l.id === selId);
+  if (idx === -1) return;
+
+  const line = lines[idx];
+  if (line.locked) return;
+
+  // Find if it's already part of a chain
+  let isChainContinuation = line.isChain === true;
+  let isChainRoot = !isChainContinuation && idx + 1 < lines.length && lines[idx + 1].isChain === true;
+  
+  if (!isChainRoot && !isChainContinuation) return; // Only works for chains
+
+  // Find chain root
+  let chainRootIndex = -1;
+  if (isChainRoot) chainRootIndex = idx;
+  else {
+    for (let i = idx; i >= 0; i--) {
+      if (!lines[i].isChain) {
+        chainRootIndex = i;
+        break;
+      }
+    }
+  }
+
+  if (chainRootIndex === -1) return;
+
+  const targetLine = lines[chainRootIndex];
+  const hasGlobalHeading = targetLine.globalHeading !== undefined;
+
+  if (hasGlobalHeading) {
+    targetLine.globalHeading = undefined;
+  } else {
+    // Enable global heading using current endPoint values
+    targetLine.globalHeading = line.endPoint.heading;
+    if (line.endPoint.degrees !== undefined) targetLine.globalDegrees = line.endPoint.degrees;
+    if (line.endPoint.targetX !== undefined) targetLine.globalTargetX = line.endPoint.targetX;
+    if (line.endPoint.targetY !== undefined) targetLine.globalTargetY = line.endPoint.targetY;
+    if (line.endPoint.reverse !== undefined) targetLine.globalReverse = line.endPoint.reverse;
+    if (line.endPoint.startDeg !== undefined) targetLine.globalStartDeg = line.endPoint.startDeg;
+    if (line.endPoint.endDeg !== undefined) targetLine.globalEndDeg = line.endPoint.endDeg;
+    
+    if (line.endPoint.segments && line.endPoint.segments.length > 0) {
+      targetLine.globalSegments = [...line.endPoint.segments];
+    } else if (line.endPoint.heading === "piecewise") {
+      targetLine.globalSegments = [{ tStart: 0, tEnd: 1, heading: "tangential", reverse: line.endPoint.reverse ?? false }];
+    }
+  }
+
+  // Sync starting point if root is index 0
+  if (chainRootIndex === 0) {
+    startPointStore.update((s) => {
+      const h = targetLine.globalHeading;
+      if (h === "constant" || h === "linear") {
+        s.heading = h;
+        if (h === "constant") s.degrees = targetLine.globalDegrees || 0;
+        else {
+          s.startDeg = targetLine.globalStartDeg || 0;
+          s.endDeg = targetLine.globalEndDeg || 0;
+        }
+      } else if (h === "tangential" || h === "facingPoint") {
+        s.heading = h;
+        if (h === "facingPoint") {
+          s.targetX = targetLine.globalTargetX || 0;
+          s.targetY = targetLine.globalTargetY || 0;
+        }
+      }
+      return { ...s };
+    });
+  }
+
+  lines[chainRootIndex] = { ...targetLine };
+  linesStore.set(lines);
+  recordChange("Toggle Global Heading");
+
+  notification.set({
+    message: `Global chain heading ${!hasGlobalHeading ? "enabled" : "disabled"}`,
+    type: "success",
+    timeout: 2000,
+  });
 }

--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -59,7 +59,7 @@
   const electronAPI = (window as any).electronAPI;
 
   async function relativizeSequenceForPreview(seq: SequenceItem[]) {
-    const cloned = structuredClone(seq);
+    const cloned = $state.snapshot(seq);
 
     const base = get(currentFilePath);
     if (!electronAPI?.makeRelativePath || !base) return cloned;

--- a/src/lib/components/tabs/PathTab.svelte
+++ b/src/lib/components/tabs/PathTab.svelte
@@ -982,6 +982,42 @@
           aria-label={isChain ? "Unchain paths" : "Chain paths"}
           onclick={() => {
             const newIsChain = !(item as any).isChain;
+
+            if (!newIsChain) {
+              // Find the root of the former chain
+              let rootIdx = sIdx;
+              while (
+                rootIdx > 0 &&
+                sequence[rootIdx - 1].kind === "path" &&
+                (sequence[rootIdx] as any).isChain
+              ) {
+                rootIdx--;
+              }
+
+              // Find the end of the former chain
+              let endIdx = sIdx;
+              while (
+                endIdx + 1 < sequence.length &&
+                sequence[endIdx + 1].kind === "path" &&
+                (sequence[endIdx + 1] as any).isChain
+              ) {
+                endIdx++;
+              }
+
+              // Reset globalHeading for all paths in the former chain island
+              for (let i = rootIdx; i <= endIdx; i++) {
+                const sItem = sequence[i];
+                if (sItem.kind === "path") {
+                  const lIdx = lines.findIndex(
+                    (l) => l.id === (sItem as any).lineId,
+                  );
+                  if (lIdx !== -1 && lines[lIdx].globalHeading !== undefined) {
+                    lines[lIdx] = { ...lines[lIdx], globalHeading: undefined };
+                  }
+                }
+              }
+            }
+
             // Need to create a new object to trigger reactivity in Svelte 5 for the `isChain` derived value
             sequence[sIdx] = { ...item, isChain: newIsChain };
 

--- a/src/lib/components/tabs/PathTab.svelte
+++ b/src/lib/components/tabs/PathTab.svelte
@@ -1097,6 +1097,7 @@
             canMoveUp={sIdx !== 0}
             canMoveDown={sIdx !== sequence.length - 1}
             {recordChange}
+            onScrollToItem={scrollToItem}
           />
         {/if}
       {:else if def && def.sectionComponent}

--- a/src/lib/exporters/javaExporter.ts
+++ b/src/lib/exporters/javaExporter.ts
@@ -304,7 +304,11 @@ export async function generateJavaCode(
 
           const constructHeadingMethod = (targetConfig: any) => {
              if (targetConfig.heading === "piecewise") {
-                const segmentsStr = (targetConfig.segments || []).map((seg: any) => {
+                const segs = targetConfig.segments || [];
+                if (segs.length === 0) {
+                   return ".setTangentHeadingInterpolation()";
+                }
+                const segmentsStr = segs.map((seg: any) => {
                    const interpStr = generateInterpolatorString(seg);
                    return `\n          new HeadingInterpolator.PiecewiseNode(${seg.tStart}, ${seg.tEnd}, ${interpStr})`;
                 }).join(",");

--- a/src/lib/exporters/javaExporter.ts
+++ b/src/lib/exporters/javaExporter.ts
@@ -254,29 +254,121 @@ export async function generateJavaCode(
               : `new BezierCurve`;
 
           let headingMethodCode = "";
-          if (line.endPoint.reverse) {
-            // Reversed: use setHeadingInterpolation(HeadingInterpolator.xxx).setReversed()
-            if (line.endPoint.heading === "constant") {
-              headingMethodCode = `.setHeadingInterpolation(HeadingInterpolator.constant(${headingConfig}))\n        .setReversed()`;
-            } else if (line.endPoint.heading === "linear") {
-              headingMethodCode = `.setHeadingInterpolation(HeadingInterpolator.linear(${headingConfig}))\n        .setReversed()`;
-            } else if (line.endPoint.heading === "tangential") {
-              // tangent is a field, not a method
-              headingMethodCode = `.setHeadingInterpolation(HeadingInterpolator.tangent)\n        .setReversed()`;
-            } else if (line.endPoint.heading === "facingPoint") {
-              headingMethodCode = `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${headingConfig}))\n        .setReversed()`;
+          let globalHeadingCode = "";
+
+          const generateInterpolatorString = (pointDef: any) => {
+            let config = "";
+            if (coordinateSystem === "FTC") {
+              if (pointDef.heading === "constant") {
+                const uh = toUserHeading(pointDef.degrees || 0, "FTC");
+                config = `Math.toRadians(${uh.toFixed(3)})`;
+              } else if (pointDef.heading === "linear") {
+                const uhStart = toUserHeading(pointDef.startDeg || 0, "FTC");
+                const uhEnd = toUserHeading(pointDef.endDeg || 0, "FTC");
+                config = `Math.toRadians(${uhStart.toFixed(3)}), Math.toRadians(${uhEnd.toFixed(3)})`;
+              } else if (pointDef.heading === "facingPoint") {
+                const uTarget = toUser({ x: pointDef.targetX || 0, y: pointDef.targetY || 0 }, "FTC");
+                config = `new Pose(${uTarget.x.toFixed(3)}, ${uTarget.y.toFixed(3)})`;
+              }
+            } else {
+              if (pointDef.heading === "constant") {
+                config = `Math.toRadians(${pointDef.degrees || 0})`;
+              } else if (pointDef.heading === "linear") {
+                config = `Math.toRadians(${pointDef.startDeg || 0}), Math.toRadians(${pointDef.endDeg || 0})`;
+              } else if (pointDef.heading === "facingPoint") {
+                const hx = codeUnits === "metric" ? `cmToInches(${((pointDef.targetX || 0) * 2.54).toFixed(3)})` : (pointDef.targetX || 0).toFixed(3);
+                const hy = codeUnits === "metric" ? `cmToInches(${((pointDef.targetY || 0) * 2.54).toFixed(3)})` : (pointDef.targetY || 0).toFixed(3);
+                config = `new Pose(${hx}, ${hy})`;
+              }
             }
-          } else {
-            // No reverse: use shorthand setters
-            if (line.endPoint.heading === "constant") {
-              headingMethodCode = `.setConstantHeadingInterpolation(${headingConfig})`;
-            } else if (line.endPoint.heading === "linear") {
-              headingMethodCode = `.setLinearHeadingInterpolation(${headingConfig})`;
-            } else if (line.endPoint.heading === "tangential") {
-              headingMethodCode = `.setTangentHeadingInterpolation()`;
-            } else if (line.endPoint.heading === "facingPoint") {
-              headingMethodCode = `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${headingConfig}))`;
+
+            let baseName = "";
+            if (pointDef.heading === "constant") {
+              baseName = `HeadingInterpolator.constant(${config})`;
+            } else if (pointDef.heading === "linear") {
+              baseName = `HeadingInterpolator.linear(${config})`;
+            } else if (pointDef.heading === "tangential") {
+              baseName = `HeadingInterpolator.tangent`;
+            } else if (pointDef.heading === "facingPoint") {
+              baseName = `HeadingInterpolator.facingPoint(${config})`;
             }
+
+            if (pointDef.reverse) {
+              if (pointDef.heading === "tangential") return "HeadingInterpolator.reversedTangent";
+              if (pointDef.heading === "linear") return `HeadingInterpolator.reversedLinear(${config})`;
+              if (pointDef.heading === "constant") return `HeadingInterpolator.reversedConstant(${config})`;
+              if (pointDef.heading === "facingPoint") return `HeadingInterpolator.reversedFacingPoint(${config})`;
+            }
+            return baseName;
+          };
+
+          const constructHeadingMethod = (targetConfig: any) => {
+             if (targetConfig.heading === "piecewise") {
+                const segmentsStr = (targetConfig.segments || []).map((seg: any) => {
+                   const interpStr = generateInterpolatorString(seg);
+                   return `\n          new HeadingInterpolator.PiecewiseNode(${seg.tStart}, ${seg.tEnd}, ${interpStr})`;
+                }).join(",");
+                return `.setHeadingInterpolation(HeadingInterpolator.piecewise(${segmentsStr}\n        ))`;
+             }
+
+             let hConfig = generateInterpolatorString(targetConfig); 
+             let args = "";
+             if (hConfig.indexOf("(") !== -1) {
+                args = hConfig.substring(hConfig.indexOf("(") + 1, hConfig.lastIndexOf(")"));
+             }
+
+             if (targetConfig.reverse) {
+               if (targetConfig.heading === "constant") {
+                 return `.setHeadingInterpolation(HeadingInterpolator.constant(${args}))\n        .setReversed()`;
+               } else if (targetConfig.heading === "linear") {
+                 return `.setHeadingInterpolation(HeadingInterpolator.linear(${args}))\n        .setReversed()`;
+               } else if (targetConfig.heading === "tangential") {
+                 return `.setHeadingInterpolation(HeadingInterpolator.tangent)\n        .setReversed()`;
+               } else if (targetConfig.heading === "facingPoint") {
+                 return `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${args}))\n        .setReversed()`;
+               }
+             } else {
+               if (targetConfig.heading === "constant") {
+                 return `.setConstantHeadingInterpolation(${args})`;
+               } else if (targetConfig.heading === "linear") {
+                 return `.setLinearHeadingInterpolation(${args})`;
+               } else if (targetConfig.heading === "tangential") {
+                 return `.setTangentHeadingInterpolation()`;
+               } else if (targetConfig.heading === "facingPoint") {
+                 return `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${args}))`;
+               }
+             }
+             return "";
+          };
+
+          const isChainRoot = !line.isChain && idx + 1 < lines.length && lines[idx + 1].isChain;
+          let hasGlobalHeading = false;
+          let tempIdx = idx;
+          let rootLine = line;
+          while(rootLine.isChain && tempIdx > 0) {
+             tempIdx--;
+             rootLine = lines[tempIdx];
+          }
+          if (rootLine.globalHeading && rootLine.globalHeading !== ("none" as any)) {
+             hasGlobalHeading = true;
+             if (!line.isChain) { 
+               const globalConfig = {
+                  heading: rootLine.globalHeading,
+                  reverse: rootLine.globalReverse,
+                  degrees: rootLine.globalDegrees,
+                  startDeg: rootLine.globalStartDeg,
+                  endDeg: rootLine.globalEndDeg,
+                  targetX: rootLine.globalTargetX,
+                  targetY: rootLine.globalTargetY,
+                  segments: rootLine.globalSegments
+               };
+               const globalInterpStr = constructHeadingMethod(globalConfig).replace(/set(Constant|Linear|Tangent|Heading)Interpolation\(/, "setGlobalHeadingInterpolation(");
+               globalHeadingCode = `\n        ${globalInterpStr}`;
+             }
+          }
+
+          if (!hasGlobalHeading) {
+             headingMethodCode = constructHeadingMethod(line.endPoint);
           }
 
           // Add event markers to the path builder
@@ -291,21 +383,25 @@ export async function generateJavaCode(
             endCode,
             headingMethodCode,
             eventMarkerCode,
+            globalHeadingCode,
           };
         });
 
         // Consolidate chained paths
         const consolidatedBlocks: string[] = [];
         let currentBlock = "";
+        let currentGlobalHeadingCode = "";
 
         for (let i = 0; i < pathData.length; i++) {
           const pd = pathData[i];
 
           if (!pd.line.isChain) {
             if (currentBlock) {
+              currentBlock += currentGlobalHeadingCode;
               currentBlock += "\n        .build();";
               consolidatedBlocks.push(currentBlock);
             }
+            currentGlobalHeadingCode = pd.globalHeadingCode;
             currentBlock = `${pd.variableName} = follower.pathBuilder()\n        .addPath(\n          ${pd.curveType}(\n            ${pd.startCode},\n            ${pd.controlPointsCode}\n            ${pd.endCode}\n          )\n        )${pd.headingMethodCode}${pd.eventMarkerCode}`;
           } else {
             currentBlock += `\n        .addPath(\n          ${pd.curveType}(\n            ${pd.startCode},\n            ${pd.controlPointsCode}\n            ${pd.endCode}\n          )\n        )${pd.headingMethodCode}${pd.eventMarkerCode}`;
@@ -313,6 +409,7 @@ export async function generateJavaCode(
         }
 
         if (currentBlock) {
+          currentBlock += currentGlobalHeadingCode;
           currentBlock += "\n        .build();";
           consolidatedBlocks.push(currentBlock);
         }

--- a/src/lib/exporters/sequentialExporter.ts
+++ b/src/lib/exporters/sequentialExporter.ts
@@ -396,54 +396,131 @@ export async function generateSequentialCommandCode(
       controlPointsStr = controlPoints.join(", ") + ", ";
     }
 
-    // Determine heading interpolation
     let headingConfig = "";
-    if (line.endPoint.heading === "constant") {
-      if (hardcodeValues) {
-        headingConfig = `setConstantHeadingInterpolation(Math.toRadians(${line.endPoint.degrees || 0}))`;
-      } else {
-        headingConfig = `setConstantHeadingInterpolation(${endPoseVar}.getHeading())`;
-      }
-    } else if (line.endPoint.heading === "linear") {
-      if (hardcodeValues) {
-        headingConfig = `setLinearHeadingInterpolation(Math.toRadians(${line.endPoint.startDeg || 0}), Math.toRadians(${line.endPoint.endDeg || 0}))`;
-      } else {
-        headingConfig = `setLinearHeadingInterpolation(${actualStartPose}.getHeading(), ${endPoseVar}.getHeading())`;
-      }
-    } else if (line.endPoint.heading === "facingPoint") {
-      let hxStr = "0";
-      let hyStr = "0";
+    // Helper to generate a HeadingInterpolator string representation (e.g. "HeadingInterpolator.tangent")
+    const generateInterpolatorString = (pointDef: any, startPoseVarInner: string, endPoseVarInner: string) => {
+      let config = "";
       if (coordinateSystem === "FTC") {
-        const uTarget = toUser(
-          {
-            x: line.endPoint.targetX || 0,
-            y: line.endPoint.targetY || 0,
-          },
-          "FTC",
-        );
-        hxStr = uTarget.x.toFixed(3);
-        hyStr = uTarget.y.toFixed(3);
+        if (pointDef.heading === "constant") {
+          // If hardcode values is disabled, we don't have access to .getHeading() on the fly easily for just the segment string unless we map it 
+          // But Piecewise with variables might be tricky, so we rely on hardcoding or variables.
+          if (hardcodeValues || pointDef.degrees !== undefined) config = `Math.toRadians(${toUserHeading(pointDef.degrees || 0, "FTC").toFixed(3)})`;
+          else config = `${endPoseVarInner}.getHeading()`;
+        } else if (pointDef.heading === "linear") {
+          if (hardcodeValues || (pointDef.startDeg !== undefined && pointDef.endDeg !== undefined)) config = `Math.toRadians(${toUserHeading(pointDef.startDeg || 0, "FTC").toFixed(3)}), Math.toRadians(${toUserHeading(pointDef.endDeg || 0, "FTC").toFixed(3)})`;
+          else config = `${startPoseVarInner}.getHeading(), ${endPoseVarInner}.getHeading()`;
+        } else if (pointDef.heading === "facingPoint") {
+          const uTarget = toUser({ x: pointDef.targetX || 0, y: pointDef.targetY || 0 }, "FTC");
+          config = `new Pose(${uTarget.x.toFixed(3)}, ${uTarget.y.toFixed(3)})`;
+        }
       } else {
-        let targetX = line.endPoint.targetX || 0;
-        let targetY = line.endPoint.targetY || 0;
-        hxStr =
-          codeUnits === "metric"
-            ? `cmToInches(${(targetX * 2.54).toFixed(3)})`
-            : targetX.toFixed(3);
-        hyStr =
-          codeUnits === "metric"
-            ? `cmToInches(${(targetY * 2.54).toFixed(3)})`
-            : targetY.toFixed(3);
+        if (pointDef.heading === "constant") {
+          if (hardcodeValues || pointDef.degrees !== undefined) config = `Math.toRadians(${pointDef.degrees || 0})`;
+          else config = `${endPoseVarInner}.getHeading()`;
+        } else if (pointDef.heading === "linear") {
+          if (hardcodeValues || (pointDef.startDeg !== undefined && pointDef.endDeg !== undefined)) config = `Math.toRadians(${pointDef.startDeg || 0}), Math.toRadians(${pointDef.endDeg || 0})`;
+          else config = `${startPoseVarInner}.getHeading(), ${endPoseVarInner}.getHeading()`;
+        } else if (pointDef.heading === "facingPoint") {
+          const targetX = pointDef.targetX || 0;
+          const targetY = pointDef.targetY || 0;
+          const hx = codeUnits === "metric" ? `cmToInches(${(targetX * 2.54).toFixed(3)})` : targetX.toFixed(3);
+          const hy = codeUnits === "metric" ? `cmToInches(${(targetY * 2.54).toFixed(3)})` : targetY.toFixed(3);
+          config = `new Pose(${hx}, ${hy})`;
+        }
       }
-      headingConfig = `setHeadingInterpolation(HeadingInterpolator.facingPoint(new Pose(${hxStr}, ${hyStr})))`;
-    } else {
-      headingConfig = `setTangentHeadingInterpolation()`;
+
+      let baseName = "";
+      if (pointDef.heading === "constant") {
+        baseName = `HeadingInterpolator.constant(${config})`;
+      } else if (pointDef.heading === "linear") {
+        baseName = `HeadingInterpolator.linear(${config})`;
+      } else if (pointDef.heading === "tangential") {
+        baseName = `HeadingInterpolator.tangent`;
+      } else if (pointDef.heading === "facingPoint") {
+        baseName = `HeadingInterpolator.facingPoint(${config})`;
+      }
+
+      if (pointDef.reverse) {
+        if (pointDef.heading === "tangential") return "HeadingInterpolator.reversedTangent";
+        if (pointDef.heading === "linear") return `HeadingInterpolator.reversedLinear(${config})`;
+        if (pointDef.heading === "constant") return `HeadingInterpolator.reversedConstant(${config})`;
+        if (pointDef.heading === "facingPoint") return `HeadingInterpolator.reversedFacingPoint(${config})`;
+      }
+      return baseName;
+    };
+
+    let headingMethodCode = "";
+    let globalHeadingCode = ""; 
+
+    const constructHeadingMethod = (targetConfig: any) => {
+      if (targetConfig.heading === "piecewise") {
+        const segmentsStr = (targetConfig.segments || []).map((seg: any) => {
+           const interpStr = generateInterpolatorString(seg, actualStartPose, endPoseVar);
+           return `\n                new HeadingInterpolator.PiecewiseNode(${seg.tStart}, ${seg.tEnd}, ${interpStr})`;
+        }).join(",");
+        return `.setHeadingInterpolation(HeadingInterpolator.piecewise(${segmentsStr}\n            ))`;
+      }
+
+      let hConfig = generateInterpolatorString(targetConfig, actualStartPose, endPoseVar); 
+      let args = "";
+      if (hConfig.indexOf("(") !== -1) {
+        args = hConfig.substring(hConfig.indexOf("(") + 1, hConfig.lastIndexOf(")"));
+      }
+
+      if (targetConfig.reverse) {
+        if (targetConfig.heading === "constant") {
+          return `.setHeadingInterpolation(HeadingInterpolator.constant(${args}))\n            .setReversed()`;
+        } else if (targetConfig.heading === "linear") {
+          return `.setHeadingInterpolation(HeadingInterpolator.linear(${args}))\n            .setReversed()`;
+        } else if (targetConfig.heading === "tangential") {
+          return `.setHeadingInterpolation(HeadingInterpolator.tangent)\n            .setReversed()`;
+        } else if (targetConfig.heading === "facingPoint") {
+          return `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${args}))\n            .setReversed()`;
+        }
+      } else {
+        if (targetConfig.heading === "constant") {
+          return `.setConstantHeadingInterpolation(${args})`;
+        } else if (targetConfig.heading === "linear") {
+          return `.setLinearHeadingInterpolation(${args})`;
+        } else if (targetConfig.heading === "tangential") {
+          return `.setTangentHeadingInterpolation()`;
+        } else if (targetConfig.heading === "facingPoint") {
+          return `.setHeadingInterpolation(HeadingInterpolator.facingPoint(${args}))`;
+        }
+      }
+      return "";
+    };
+
+    const isChainRoot = !line.isChain && idx + 1 < lines.length && lines[idx + 1].isChain;
+    let hasGlobalHeading = false;
+    
+    let tempIdx = idx;
+    let rootLine = line;
+    while(rootLine.isChain && tempIdx > 0) {
+       tempIdx--;
+       rootLine = lines[tempIdx];
+    }
+    if (rootLine.globalHeading && rootLine.globalHeading !== ("none" as any)) {
+       hasGlobalHeading = true;
+       if (!line.isChain) { 
+         const globalConfig = {
+            heading: rootLine.globalHeading,
+            reverse: rootLine.globalReverse,
+            degrees: rootLine.globalDegrees,
+            startDeg: rootLine.globalStartDeg,
+            endDeg: rootLine.globalEndDeg,
+            targetX: rootLine.globalTargetX,
+            targetY: rootLine.globalTargetY,
+            segments: rootLine.globalSegments
+         };
+         const globalInterpStr = constructHeadingMethod(globalConfig).replace(/set(Constant|Linear|Tangent|Heading)Interpolation\(/, "setGlobalHeadingInterpolation(");
+         globalHeadingCode = `\n            ${globalInterpStr}`;
+       }
     }
 
-    // Build reverse config
-    const reverseConfig = line.endPoint.reverse
-      ? "\n                .setReversed()"
-      : "";
+    if (!hasGlobalHeading) {
+       headingMethodCode = constructHeadingMethod(line.endPoint);
+    }
 
     if (!line.isChain) {
       if (currentBuilderStr !== "") {
@@ -452,11 +529,11 @@ export async function generateSequentialCommandCode(
       }
       currentBuilderStr = `        ${pathName} = follower.pathBuilder()
             .addPath(new ${curveType}(${actualStartPose}, ${controlPointsStr}${endPoseVar}))
-            .${headingConfig}${reverseConfig}`;
+            ${headingMethodCode}${globalHeadingCode}`;
     } else {
       currentBuilderStr += `
             .addPath(new ${curveType}(${actualStartPose}, ${controlPointsStr}${endPoseVar}))
-            .${headingConfig}${reverseConfig}`;
+            ${headingMethodCode}`;
     }
   });
 

--- a/src/tests/components/renderer/generators.test.ts
+++ b/src/tests/components/renderer/generators.test.ts
@@ -64,7 +64,13 @@ describe("Renderer Generators", () => {
       } as any,
     ];
 
-    const points = generatePointElements(startPoint, lines, shapes, ctx as any);
+    const points = generatePointElements(
+      startPoint,
+      lines,
+      shapes,
+      [] as any,
+      ctx as any,
+    );
     expect(points.length).toBe(5);
     const sp = points[0] as InstanceType<typeof Two.Circle>;
     expect(sp.id).toBe("point-0-0");

--- a/src/tests/math.test.ts
+++ b/src/tests/math.test.ts
@@ -267,6 +267,33 @@ describe("Math Utils", () => {
       // Should skip (0,0) and use (5,5), angle 45
       expect(getLineStartHeading(line, prev)).toBe(45);
     });
+
+    it("interpolates piecewise linear headings across a global chain", () => {
+      const p1 = { x: 0, y: 0 } as Point;
+      const globalOverride = {
+        id: "root-line",
+        globalHeading: "piecewise",
+        globalSegments: [
+          {
+            tStart: 0,
+            tEnd: 1,
+            heading: "linear",
+            startDeg: 0,
+            endDeg: 180,
+          },
+        ],
+      } as any;
+
+      const res = getLineStartHeading(
+        { id: "line-2", endPoint: {} } as any,
+        p1,
+        globalOverride,
+        20, // totalChainDistance
+        10, // distanceBefore
+      );
+
+      expect(res).toBe(90);
+    });
   });
 
   describe("splitBezier", () => {
@@ -411,6 +438,33 @@ describe("Math Utils", () => {
       // Should skip (10,10) and use (5,5) as prev point for tangent
       // Tangent from (5,5) to (10,10) is 45 degrees
       expect(getLineEndHeading(line, prev)).toBe(45);
+    });
+
+    it("interpolates piecewise linear headings across a global chain", () => {
+      const p1 = { x: 0, y: 0 } as Point;
+      const globalOverride = {
+        id: "root-line",
+        globalHeading: "piecewise",
+        globalSegments: [
+          {
+            tStart: 0,
+            tEnd: 1,
+            heading: "linear",
+            startDeg: 0,
+            endDeg: 180,
+          },
+        ],
+      } as any;
+
+      const res = getLineEndHeading(
+        { id: "line-2", endPoint: {} } as any,
+        p1,
+        globalOverride,
+        20, // totalChainDistance
+        15, // distanceAtEnd
+      );
+
+      expect(res).toBe(135);
     });
   });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,46 @@ export interface BasePoint {
   originalId?: string;
 }
 
+export type PiecewiseSegment = {
+  tStart: number;
+  tEnd: number;
+} & (
+  | {
+      heading: "linear";
+      startDeg: number;
+      endDeg: number;
+      degrees?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "constant";
+      degrees: number;
+      startDeg?: never;
+      endDeg?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "tangential";
+      degrees?: never;
+      startDeg?: never;
+      endDeg?: never;
+      targetX?: never;
+      targetY?: never;
+    }
+  | {
+      heading: "facingPoint";
+      targetX: number;
+      targetY: number;
+      degrees?: never;
+      startDeg?: never;
+      endDeg?: never;
+    }
+) & {
+    reverse?: boolean;
+  };
+
 export type Point = BasePoint &
   (
     | {
@@ -20,6 +60,7 @@ export type Point = BasePoint &
         degrees?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "constant";
@@ -28,6 +69,7 @@ export type Point = BasePoint &
         endDeg?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "tangential";
@@ -36,6 +78,7 @@ export type Point = BasePoint &
         endDeg?: never;
         targetX?: never;
         targetY?: never;
+        segments?: never;
       }
     | {
         heading: "facingPoint";
@@ -44,6 +87,16 @@ export type Point = BasePoint &
         degrees?: never;
         startDeg?: never;
         endDeg?: never;
+        segments?: never;
+      }
+    | {
+        heading: "piecewise";
+        segments: PiecewiseSegment[];
+        degrees?: never;
+        startDeg?: never;
+        endDeg?: never;
+        targetX?: never;
+        targetY?: never;
       }
   ) & {
     reverse?: boolean;
@@ -91,6 +144,14 @@ export interface Line {
   macroId?: string;
   originalId?: string;
   isChain?: boolean;
+  globalHeading?: Point["heading"] | "none"; // Used when isChain is true, acts as a global override
+  globalDegrees?: number;
+  globalStartDeg?: number;
+  globalEndDeg?: number;
+  globalTargetX?: number;
+  globalTargetY?: number;
+  globalReverse?: boolean;
+  globalSegments?: PiecewiseSegment[];
 }
 
 export type SequencePathItem = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,33 +19,33 @@ export type PiecewiseSegment = {
       heading: "linear";
       startDeg: number;
       endDeg: number;
-      degrees?: never;
-      targetX?: never;
-      targetY?: never;
+      degrees?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "constant";
       degrees: number;
-      startDeg?: never;
-      endDeg?: never;
-      targetX?: never;
-      targetY?: never;
+      startDeg?: undefined;
+      endDeg?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "tangential";
-      degrees?: never;
-      startDeg?: never;
-      endDeg?: never;
-      targetX?: never;
-      targetY?: never;
+      degrees?: undefined;
+      startDeg?: undefined;
+      endDeg?: undefined;
+      targetX?: undefined;
+      targetY?: undefined;
     }
   | {
       heading: "facingPoint";
       targetX: number;
       targetY: number;
-      degrees?: never;
-      startDeg?: never;
-      endDeg?: never;
+      degrees?: undefined;
+      startDeg?: undefined;
+      endDeg?: undefined;
     }
 ) & {
     reverse?: boolean;
@@ -57,46 +57,46 @@ export type Point = BasePoint &
         heading: "linear";
         startDeg: number;
         endDeg: number;
-        degrees?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        degrees?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "constant";
         degrees: number;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "tangential";
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
-        segments?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "facingPoint";
         targetX: number;
         targetY: number;
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        segments?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        segments?: undefined;
       }
     | {
         heading: "piecewise";
         segments: PiecewiseSegment[];
-        degrees?: never;
-        startDeg?: never;
-        endDeg?: never;
-        targetX?: never;
-        targetY?: never;
+        degrees?: undefined;
+        startDeg?: undefined;
+        endDeg?: undefined;
+        targetX?: undefined;
+        targetY?: undefined;
       }
   ) & {
     reverse?: boolean;
@@ -380,6 +380,9 @@ export interface TimelineEvent {
   velocityProfile?: number[];
   // Detailed heading profile for travel events: maps step index to unwrapped heading
   headingProfile?: number[];
+  isGlobalOverride?: boolean;
+  rootLine?: Line;
+  globalHeading?: Point["heading"];
 }
 
 export interface TimePrediction {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -70,6 +70,18 @@ interface TimePrediction {
   timeline: TimelineEvent[];
 }
 
+type PiecewiseSegment = {
+  tStart: number;
+  tEnd: number;
+  heading: "constant" | "linear" | "tangential" | "facingPoint";
+  degrees?: number;
+  startDeg?: number;
+  endDeg?: number;
+  targetX?: number;
+  targetY?: number;
+  reverse?: boolean;
+};
+
 type Point = BasePoint &
   (
     | {
@@ -78,6 +90,9 @@ type Point = BasePoint &
         endDeg: number;
         degrees?: never;
         reverse?: never;
+        targetX?: never;
+        targetY?: never;
+        segments?: never;
       }
     | {
         heading: "constant";
@@ -85,6 +100,9 @@ type Point = BasePoint &
         startDeg?: never;
         endDeg?: never;
         reverse?: never;
+        targetX?: never;
+        targetY?: never;
+        segments?: never;
       }
     | {
         heading: "tangential";
@@ -92,6 +110,29 @@ type Point = BasePoint &
         startDeg?: never;
         endDeg?: never;
         reverse: boolean;
+        targetX?: never;
+        targetY?: never;
+        segments?: never;
+      }
+    | {
+        heading: "facingPoint";
+        targetX: number;
+        targetY: number;
+        reverse?: boolean;
+        degrees?: never;
+        startDeg?: never;
+        endDeg?: never;
+        segments?: never;
+      }
+    | {
+        heading: "piecewise";
+        segments: PiecewiseSegment[];
+        degrees?: never;
+        startDeg?: never;
+        endDeg?: never;
+        targetX?: never;
+        targetY?: never;
+        reverse?: never;
       }
   );
 
@@ -112,6 +153,14 @@ interface Line {
   waitBeforeName?: string;
   waitAfterName?: string;
   isChain?: boolean;
+  globalHeading?: Point["heading"]; // Used when isChain is true, acts as a global override
+  globalDegrees?: number;
+  globalStartDeg?: number;
+  globalEndDeg?: number;
+  globalTargetX?: number;
+  globalTargetY?: number;
+  globalReverse?: boolean;
+  globalSegments?: PiecewiseSegment[];
 }
 
 type SequencePathItem = {

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -203,54 +203,83 @@ export function getLineStartHeading(
   line: Line | undefined,
   previousPoint: Point,
   globalOverride?: Line,
+  totalChainDistance?: number,
+  distanceBefore?: number,
 ): number {
   if (!line || !line.endPoint) return 0;
 
-  const effectiveSource =
+  const isGlobal =
     globalOverride &&
     globalOverride.globalHeading &&
-    globalOverride.globalHeading !== "none"
-      ? {
-          heading: globalOverride.globalHeading,
-          degrees: globalOverride.globalDegrees,
-          startDeg: globalOverride.globalStartDeg,
-          endDeg: globalOverride.globalEndDeg,
-          targetX: globalOverride.globalTargetX,
-          targetY: globalOverride.globalTargetY,
-          reverse: globalOverride.globalReverse,
-          segments: globalOverride.globalSegments,
-        }
-      : line.endPoint;
+    globalOverride.globalHeading !== "none";
 
-  if (effectiveSource.heading === "linear") return (effectiveSource as any).startDeg;
+  const effectiveSource = isGlobal
+    ? {
+        heading: globalOverride!.globalHeading,
+        degrees: globalOverride!.globalDegrees,
+        startDeg: globalOverride!.globalStartDeg,
+        endDeg: globalOverride!.globalEndDeg,
+        targetX: globalOverride!.globalTargetX,
+        targetY: globalOverride!.globalTargetY,
+        reverse: globalOverride!.globalReverse,
+        segments: globalOverride!.globalSegments,
+      }
+    : line.endPoint;
+
+  if (effectiveSource.heading === "linear")
+    return (effectiveSource as any).startDeg;
 
   if (effectiveSource.heading === "piecewise") {
     const segments = (effectiveSource as any).segments || [];
-    let firstSeg = null;
+    const t =
+      isGlobal && totalChainDistance && totalChainDistance > 0
+        ? (distanceBefore || 0) / totalChainDistance
+        : 0;
+
+    let activeSeg = null;
     for (const seg of segments) {
-      if (0 >= seg.tStart && 0 <= seg.tEnd) {
-        firstSeg = seg;
+      if (t >= seg.tStart && t <= seg.tEnd) {
+        activeSeg = seg;
         break;
       }
     }
-    if (!firstSeg && segments.length > 0) firstSeg = segments[0];
+    if (!activeSeg && segments.length > 0) activeSeg = segments[0];
 
-    if (firstSeg) {
-      if (firstSeg.heading === "linear") return firstSeg.startDeg ?? 0;
-      if (firstSeg.heading === "constant")
+    if (activeSeg) {
+      if (activeSeg.heading === "linear") {
+        const sDeg = activeSeg.startDeg ?? 0;
+        const eDeg = activeSeg.endDeg ?? 0;
+        let localT = 0;
+        if (activeSeg.tEnd > activeSeg.tStart) {
+          localT = (t - activeSeg.tStart) / (activeSeg.tEnd - activeSeg.tStart);
+        }
+
+        const diff = eDeg - sDeg;
+        const normalized = ((diff % 360) + 360) % 360;
+        const shortest = normalized > 180 ? normalized - 360 : normalized;
+        const longest = shortest > 0 ? shortest - 360 : shortest + 360;
+
+        return transformAngle(sDeg + (activeSeg.reverse ? longest : shortest) * localT);
+      }
+      if (activeSeg.heading === "constant")
         return transformAngle(
-          (firstSeg.degrees ?? 0) + (firstSeg.reverse ? 180 : 0),
+          (activeSeg.degrees ?? 0) + (activeSeg.reverse ? 180 : 0),
         );
 
       let nextP: Point2D = line.endPoint;
-      if (
-        firstSeg.heading === "tangential" &&
-        line.controlPoints?.length > 0
-      ) {
+      if (activeSeg.heading === "tangential" && line.controlPoints?.length > 0) {
         nextP =
           getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
+      } else if (activeSeg.heading === "facingPoint") {
+        const tx = activeSeg.targetX || 0;
+        const ty = activeSeg.targetY || 0;
+        // Piecewise start always uses t=0 for geometry lookup
+        const pos = previousPoint;
+        let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
+        if (activeSeg.reverse) angle += 180;
+        return transformAngle(angle);
       }
-      return getHeadingBase(firstSeg as any, previousPoint, nextP);
+      return getHeadingBase(activeSeg as any, previousPoint, nextP);
     }
     return 0;
   }
@@ -279,33 +308,42 @@ export function getLineEndHeading(
   line: Line | undefined,
   previousPoint: Point,
   globalOverride?: Line,
+  totalChainDistance?: number,
+  distanceAtEnd?: number,
 ): number {
   if (!line || !line.endPoint) return 0;
 
-  const effectiveSource =
+  const isGlobal =
     globalOverride &&
     globalOverride.globalHeading &&
-    globalOverride.globalHeading !== "none"
-      ? {
-          heading: globalOverride.globalHeading,
-          degrees: globalOverride.globalDegrees,
-          startDeg: globalOverride.globalStartDeg,
-          endDeg: globalOverride.globalEndDeg,
-          targetX: globalOverride.globalTargetX,
-          targetY: globalOverride.globalTargetY,
-          reverse: globalOverride.globalReverse,
-          segments: globalOverride.globalSegments,
-        }
-      : line.endPoint;
+    globalOverride.globalHeading !== "none";
+
+  const effectiveSource = isGlobal
+    ? {
+        heading: globalOverride!.globalHeading,
+        degrees: globalOverride!.globalDegrees,
+        startDeg: globalOverride!.globalStartDeg,
+        endDeg: globalOverride!.globalEndDeg,
+        targetX: globalOverride!.globalTargetX,
+        targetY: globalOverride!.globalTargetY,
+        reverse: globalOverride!.globalReverse,
+        segments: globalOverride!.globalSegments,
+      }
+    : line.endPoint;
 
   if (effectiveSource.heading === "linear")
     return (effectiveSource as any).endDeg;
 
   if (effectiveSource.heading === "piecewise") {
     const segments = (effectiveSource as any).segments || [];
+    const t =
+      isGlobal && totalChainDistance && totalChainDistance > 0
+        ? (distanceAtEnd || 0) / totalChainDistance
+        : 1.0;
+
     let lastSeg = null;
     for (const seg of segments) {
-      if (1 >= seg.tStart && 1 <= seg.tEnd) {
+      if (t >= seg.tStart && t <= seg.tEnd) {
         lastSeg = seg;
         break;
       }
@@ -317,14 +355,17 @@ export function getLineEndHeading(
       if (lastSeg.heading === "linear") {
         const sDeg = lastSeg.startDeg ?? 0;
         const eDeg = lastSeg.endDeg ?? 0;
-        if (lastSeg.reverse) {
-          const shortDiff = eDeg - sDeg;
-          const normalizedShort = ((shortDiff % 360) + 360) % 360;
-          const longDiff =
-            normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
-          return sDeg + longDiff;
+        let localT = 0;
+        if (lastSeg.tEnd > lastSeg.tStart) {
+          localT = (t - lastSeg.tStart) / (lastSeg.tEnd - lastSeg.tStart);
         }
-        return eDeg;
+
+        const diff = eDeg - sDeg;
+        const normalized = ((diff % 360) + 360) % 360;
+        const shortest = normalized > 180 ? normalized - 360 : normalized;
+        const longest = shortest > 0 ? shortest - 360 : shortest + 360;
+
+        return transformAngle(sDeg + (lastSeg.reverse ? longest : shortest) * localT);
       }
       if (lastSeg.heading === "constant")
         return transformAngle(
@@ -336,6 +377,13 @@ export function getLineEndHeading(
         prevP =
           getFirstValidControlPoint(line.controlPoints, line.endPoint, true) ||
           prevP;
+      } else if (lastSeg.heading === "facingPoint") {
+        const tx = lastSeg.targetX || 0;
+        const ty = lastSeg.targetY || 0;
+        const pos = line.endPoint;
+        let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
+        if (lastSeg.reverse) angle += 180;
+        return transformAngle(angle);
       }
       return getHeadingBase(
         lastSeg as any,

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -206,6 +206,33 @@ export function getLineStartHeading(
   if (!line || !line.endPoint) return 0;
   if (line.endPoint.heading === "linear") return line.endPoint.startDeg;
 
+  if (line.endPoint.heading === "piecewise") {
+    const segments = line.endPoint.segments || [];
+    let firstSeg = null;
+    for (const seg of segments) {
+      if (0 >= seg.tStart && 0 <= seg.tEnd) {
+        firstSeg = seg;
+        break;
+      }
+    }
+    if (!firstSeg && segments.length > 0) firstSeg = segments[0];
+
+    if (firstSeg) {
+      if (firstSeg.heading === "linear") return firstSeg.startDeg ?? 0;
+      if (firstSeg.heading === "constant") return transformAngle((firstSeg.degrees ?? 0) + (firstSeg.reverse ? 180 : 0));
+      
+      let nextP: Point2D = line.endPoint;
+      if (
+        firstSeg.heading === "tangential" &&
+        line.controlPoints?.length > 0
+      ) {
+        nextP = getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
+      }
+      return getHeadingBase(firstSeg as any, previousPoint, nextP);
+    }
+    return 0;
+  }
+
   let nextP: Point2D = line.endPoint;
   if (
     line.endPoint.heading === "tangential" &&
@@ -232,6 +259,47 @@ export function getLineEndHeading(
 ): number {
   if (!line || !line.endPoint) return 0;
   if (line.endPoint.heading === "linear") return line.endPoint.endDeg;
+
+  if (line.endPoint.heading === "piecewise") {
+    const segments = line.endPoint.segments || [];
+    let lastSeg = null;
+    for (const seg of segments) {
+      if (1 >= seg.tStart && 1 <= seg.tEnd) {
+        lastSeg = seg;
+        break;
+      }
+    }
+    if (!lastSeg && segments.length > 0) lastSeg = segments[segments.length - 1];
+
+    if (lastSeg) {
+      if (lastSeg.heading === "linear") {
+         const sDeg = lastSeg.startDeg ?? 0;
+         const eDeg = lastSeg.endDeg ?? 0;
+         if (lastSeg.reverse) {
+            const shortDiff = eDeg - sDeg;
+            const normalizedShort = ((shortDiff % 360) + 360) % 360;
+            const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+            return sDeg + longDiff;
+         }
+         return eDeg;
+      }
+      if (lastSeg.heading === "constant") return transformAngle((lastSeg.degrees ?? 0) + (lastSeg.reverse ? 180 : 0));
+      
+      let prevP: Point2D = previousPoint;
+      if (
+        lastSeg.heading === "tangential" &&
+        line.controlPoints?.length > 0
+      ) {
+        prevP = getFirstValidControlPoint(line.controlPoints, line.endPoint, true) || prevP;
+      }
+      return getHeadingBase(
+        lastSeg as any,
+        lastSeg.heading === "facingPoint" ? line.endPoint : prevP,
+        line.endPoint,
+      );
+    }
+    return 0;
+  }
 
   let prevP: Point2D = previousPoint;
   if (

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -202,12 +202,30 @@ function getHeadingBase(
 export function getLineStartHeading(
   line: Line | undefined,
   previousPoint: Point,
+  globalOverride?: Line,
 ): number {
   if (!line || !line.endPoint) return 0;
-  if (line.endPoint.heading === "linear") return line.endPoint.startDeg;
 
-  if (line.endPoint.heading === "piecewise") {
-    const segments = line.endPoint.segments || [];
+  const effectiveSource =
+    globalOverride &&
+    globalOverride.globalHeading &&
+    globalOverride.globalHeading !== "none"
+      ? {
+          heading: globalOverride.globalHeading,
+          degrees: globalOverride.globalDegrees,
+          startDeg: globalOverride.globalStartDeg,
+          endDeg: globalOverride.globalEndDeg,
+          targetX: globalOverride.globalTargetX,
+          targetY: globalOverride.globalTargetY,
+          reverse: globalOverride.globalReverse,
+          segments: globalOverride.globalSegments,
+        }
+      : line.endPoint;
+
+  if (effectiveSource.heading === "linear") return (effectiveSource as any).startDeg;
+
+  if (effectiveSource.heading === "piecewise") {
+    const segments = (effectiveSource as any).segments || [];
     let firstSeg = null;
     for (const seg of segments) {
       if (0 >= seg.tStart && 0 <= seg.tEnd) {
@@ -219,14 +237,18 @@ export function getLineStartHeading(
 
     if (firstSeg) {
       if (firstSeg.heading === "linear") return firstSeg.startDeg ?? 0;
-      if (firstSeg.heading === "constant") return transformAngle((firstSeg.degrees ?? 0) + (firstSeg.reverse ? 180 : 0));
-      
+      if (firstSeg.heading === "constant")
+        return transformAngle(
+          (firstSeg.degrees ?? 0) + (firstSeg.reverse ? 180 : 0),
+        );
+
       let nextP: Point2D = line.endPoint;
       if (
         firstSeg.heading === "tangential" &&
         line.controlPoints?.length > 0
       ) {
-        nextP = getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
+        nextP =
+          getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
       }
       return getHeadingBase(firstSeg as any, previousPoint, nextP);
     }
@@ -235,14 +257,14 @@ export function getLineStartHeading(
 
   let nextP: Point2D = line.endPoint;
   if (
-    line.endPoint.heading === "tangential" &&
+    effectiveSource.heading === "tangential" &&
     line.controlPoints?.length > 0
   ) {
     nextP =
       getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
   }
 
-  return getHeadingBase(line.endPoint, previousPoint, nextP);
+  return getHeadingBase(effectiveSource as any, previousPoint, nextP);
 }
 
 export function getInitialTangentialHeading(
@@ -256,12 +278,31 @@ export function getInitialTangentialHeading(
 export function getLineEndHeading(
   line: Line | undefined,
   previousPoint: Point,
+  globalOverride?: Line,
 ): number {
   if (!line || !line.endPoint) return 0;
-  if (line.endPoint.heading === "linear") return line.endPoint.endDeg;
 
-  if (line.endPoint.heading === "piecewise") {
-    const segments = line.endPoint.segments || [];
+  const effectiveSource =
+    globalOverride &&
+    globalOverride.globalHeading &&
+    globalOverride.globalHeading !== "none"
+      ? {
+          heading: globalOverride.globalHeading,
+          degrees: globalOverride.globalDegrees,
+          startDeg: globalOverride.globalStartDeg,
+          endDeg: globalOverride.globalEndDeg,
+          targetX: globalOverride.globalTargetX,
+          targetY: globalOverride.globalTargetY,
+          reverse: globalOverride.globalReverse,
+          segments: globalOverride.globalSegments,
+        }
+      : line.endPoint;
+
+  if (effectiveSource.heading === "linear")
+    return (effectiveSource as any).endDeg;
+
+  if (effectiveSource.heading === "piecewise") {
+    const segments = (effectiveSource as any).segments || [];
     let lastSeg = null;
     for (const seg of segments) {
       if (1 >= seg.tStart && 1 <= seg.tEnd) {
@@ -269,28 +310,32 @@ export function getLineEndHeading(
         break;
       }
     }
-    if (!lastSeg && segments.length > 0) lastSeg = segments[segments.length - 1];
+    if (!lastSeg && segments.length > 0)
+      lastSeg = segments[segments.length - 1];
 
     if (lastSeg) {
       if (lastSeg.heading === "linear") {
-         const sDeg = lastSeg.startDeg ?? 0;
-         const eDeg = lastSeg.endDeg ?? 0;
-         if (lastSeg.reverse) {
-            const shortDiff = eDeg - sDeg;
-            const normalizedShort = ((shortDiff % 360) + 360) % 360;
-            const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
-            return sDeg + longDiff;
-         }
-         return eDeg;
+        const sDeg = lastSeg.startDeg ?? 0;
+        const eDeg = lastSeg.endDeg ?? 0;
+        if (lastSeg.reverse) {
+          const shortDiff = eDeg - sDeg;
+          const normalizedShort = ((shortDiff % 360) + 360) % 360;
+          const longDiff =
+            normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+          return sDeg + longDiff;
+        }
+        return eDeg;
       }
-      if (lastSeg.heading === "constant") return transformAngle((lastSeg.degrees ?? 0) + (lastSeg.reverse ? 180 : 0));
-      
+      if (lastSeg.heading === "constant")
+        return transformAngle(
+          (lastSeg.degrees ?? 0) + (lastSeg.reverse ? 180 : 0),
+        );
+
       let prevP: Point2D = previousPoint;
-      if (
-        lastSeg.heading === "tangential" &&
-        line.controlPoints?.length > 0
-      ) {
-        prevP = getFirstValidControlPoint(line.controlPoints, line.endPoint, true) || prevP;
+      if (lastSeg.heading === "tangential" && line.controlPoints?.length > 0) {
+        prevP =
+          getFirstValidControlPoint(line.controlPoints, line.endPoint, true) ||
+          prevP;
       }
       return getHeadingBase(
         lastSeg as any,
@@ -303,7 +348,7 @@ export function getLineEndHeading(
 
   let prevP: Point2D = previousPoint;
   if (
-    line.endPoint.heading === "tangential" &&
+    effectiveSource.heading === "tangential" &&
     line.controlPoints?.length > 0
   ) {
     prevP =
@@ -312,8 +357,8 @@ export function getLineEndHeading(
   }
 
   return getHeadingBase(
-    line.endPoint,
-    line.endPoint.heading === "facingPoint" ? line.endPoint : prevP,
+    effectiveSource as any,
+    effectiveSource.heading === "facingPoint" ? line.endPoint : prevP,
     line.endPoint,
   );
 }

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -1009,17 +1009,22 @@ export function calculatePathTime(
         const rev = isGlobalOverride
           ? rootLine.globalReverse
           : (line.endPoint as any).reverse;
+
         if (rev) {
+          // Pedro Pathing reversed linear forces shortest path in opposite direction
           const shortDiff = endDeg - startDeg;
           const normalizedShort = ((shortDiff % 360) + 360) % 360;
           const longDiff =
             normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
-          endHeading = unwrapAngle(startDeg + longDiff, currentHeading);
+          const startUnwound = unwrapAngle(startDeg, currentHeading);
+          endHeading = startUnwound + longDiff;
           rotationRequired = Math.abs(longDiff);
         } else {
-          endHeading = unwrapAngle(endDeg, currentHeading);
+          // Support multi-revolution: preserve the user's start-to-end difference
           const startUnwound = unwrapAngle(startDeg, currentHeading);
-          rotationRequired = Math.abs(endHeading - startUnwound);
+          const totalDiff = endDeg - startDeg;
+          endHeading = startUnwound + totalDiff;
+          rotationRequired = Math.abs(totalDiff);
         }
       } else if (effectiveHeading === "facingPoint") {
         const targetX = isGlobalOverride
@@ -1325,16 +1330,17 @@ export function calculatePathTime(
                if (localT < 0) localT = 0;
                if (localT > 1) localT = 1;
                
+               const startUnwound = unwrapAngle(sDeg, simHeading);
                if (activeSeg.reverse) {
+                  // Shortest path in long direction logic
                   const shortDiff = eDeg - sDeg;
                   const normalizedShort = ((shortDiff % 360) + 360) % 360;
                   const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
-                  const startUnwound = unwrapAngle(sDeg, simHeading);
                   targetHeading = startUnwound + longDiff * localT;
                } else {
-                  let endUnwound = unwrapAngle(eDeg, simHeading);
-                  let startUnwound = unwrapAngle(sDeg, simHeading);
-                  targetHeading = startUnwound + (endUnwound - startUnwound) * localT;
+                  // Support multi-revolution: preserve actual range
+                  const totalDiff = eDeg - sDeg;
+                  targetHeading = startUnwound + totalDiff * localT;
                }
             } else if (activeSeg.heading === "facingPoint") {
                const targetX = activeSeg.targetX || 0;

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -665,25 +665,73 @@ export function calculatePathTime(
   const segmentTimes: number[] = [];
   const timeline: TimelineEvent[] = [];
 
+  const globalChainMeta = sequence
+    ? calculateGlobalChainMeta(sequence, lines, startPoint)
+    : new Map();
+
   let currentTime = 0;
   let currentHeading = 0;
   let isFirstPathItem = true;
 
   // Initialize heading based on start point settings
+  // But OVERRIDE if the first path in the sequence has a global chain override
+  let startOverrideFound = false;
+  if (sequence && sequence.length > 0) {
+    const firstPathItem = sequence.find((it) => it.kind === "path");
+    if (firstPathItem) {
+      const lineId = (firstPathItem as any).lineId;
+      const line = lines.find((l) => l.id === lineId);
+      if (line) {
+        const meta = globalChainMeta.get(line.id!);
+        const rootLine = meta?.rootLine;
+        if (rootLine?.globalHeading && rootLine.globalHeading !== "none") {
+          const effectiveHeading = rootLine.globalHeading;
+          if (effectiveHeading === "tangential") {
+            const nextP =
+              line.controlPoints.length > 0
+                ? line.controlPoints[0]
+                : line.endPoint;
+            currentHeading = getInitialTangentialHeading(startPoint, nextP);
+            startOverrideFound = true;
+          } else if (effectiveHeading === "constant") {
+            const deg = rootLine.globalDegrees || 0;
+            const rev = rootLine.globalReverse;
+            currentHeading = rev ? deg + 180 : deg;
+            startOverrideFound = true;
+          } else if (effectiveHeading === "linear") {
+            const deg = rootLine.globalStartDeg || 0;
+            const rev = rootLine.globalReverse;
+            currentHeading = rev ? deg + 180 : deg;
+            startOverrideFound = true;
+          } else if (effectiveHeading === "facingPoint") {
+            const tx = rootLine.globalTargetX || 0;
+            const ty = rootLine.globalTargetY || 0;
+            const rev = rootLine.globalReverse;
+            let angle = Math.atan2(ty - startPoint.y, tx - startPoint.x) * (180 / Math.PI);
+            if (rev) angle += 180;
+            currentHeading = angle;
+            startOverrideFound = true;
+          }
+        }
+      }
+    }
+  }
 
-  if (startPoint.heading === "linear") currentHeading = startPoint.startDeg;
-  else if (startPoint.heading === "constant")
-    currentHeading = startPoint.degrees;
-  else if (startPoint.heading === "tangential") {
-    if (lines.length > 0) {
-      const firstLine = lines[0];
-      const nextP =
-        firstLine.controlPoints.length > 0
-          ? firstLine.controlPoints[0]
-          : firstLine.endPoint;
-      currentHeading = getInitialTangentialHeading(startPoint, nextP);
-    } else {
-      currentHeading = 0;
+  if (!startOverrideFound) {
+    if (startPoint.heading === "linear") currentHeading = startPoint.startDeg;
+    else if (startPoint.heading === "constant")
+      currentHeading = startPoint.degrees;
+    else if (startPoint.heading === "tangential") {
+      if (lines.length > 0) {
+        const firstLine = lines[0];
+        const nextP =
+          firstLine.controlPoints.length > 0
+            ? firstLine.controlPoints[0]
+            : firstLine.endPoint;
+        currentHeading = getInitialTangentialHeading(startPoint, nextP);
+      } else {
+        currentHeading = 0;
+      }
     }
   }
 

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -825,6 +825,8 @@ export function calculatePathTime(
         line,
         prevPoint,
         rootLine,
+        chainMeta?.chainTotalLength,
+        chainMeta?.distanceBefore,
       );
       // Unwind: find value closest to currentHeading
       let requiredStartHeading = unwrapAngle(
@@ -905,7 +907,13 @@ export function calculatePathTime(
             if (prevLine) {
               // Start of the previous line isn't immediately available, but we can rough it from currentHeading
               // A better heuristic is to look at the immediate start angle of this line vs the inherited currentHeading
-              let thisStartHeading = getLineStartHeading(line, prevPoint, rootLine);
+              let thisStartHeading = getLineStartHeading(
+                line,
+                prevPoint,
+                rootLine,
+                chainMeta?.chainTotalLength,
+                chainMeta?.distanceBefore,
+              );
               let diff = Math.abs(
                 getAngularDifference(currentHeading, thisStartHeading),
               );
@@ -922,10 +930,13 @@ export function calculatePathTime(
           let nextLine = lineById.get((nextItem as any).lineId);
           if (nextLine) {
             let thisEndHeading = getLineEndHeading(line, prevPoint);
+            const nextChainMeta = globalChainMeta.get(nextLine.id!);
             let nextStartHeading = getLineStartHeading(
               nextLine,
               line.endPoint as Point,
-              globalChainMeta.get(nextLine.id!)?.rootLine,
+              nextChainMeta?.rootLine,
+              nextChainMeta?.chainTotalLength,
+              nextChainMeta?.distanceBefore,
             );
             let diff = Math.abs(
               getAngularDifference(thisEndHeading, nextStartHeading),
@@ -954,12 +965,15 @@ export function calculatePathTime(
       let rotationRequired = 0;
 
       // Determine End Heading (Unwound)
-      let endHeadingRaw = getLineEndHeading(line, prevPoint, rootLine);
+      let endHeadingRaw = getLineEndHeading(
+        line,
+        prevPoint,
+        rootLine,
+        chainMeta?.chainTotalLength,
+        (chainMeta?.distanceBefore || 0) + length,
+      );
       let endHeading = endHeadingRaw;
 
-      // Resolve global chain heading override for endHeading/rotation calculation
-      // const chainMeta = globalChainMeta.get(line.id!);
-      // const rootLine = chainMeta?.rootLine;
       const isGlobalOverride = !!(
         rootLine?.globalHeading && rootLine.globalHeading !== "none"
       );
@@ -1113,6 +1127,10 @@ export function calculatePathTime(
         const cTotalLen = chainMeta ? chainMeta.chainTotalLength : length;
         const cDistBefore = chainMeta ? chainMeta.distanceBefore : 0;
 
+        const maxAngVelDegPerSec =
+          Math.max(safeSettings.aVelocity, 0.001) * (180 / Math.PI);
+        const eps = 0.005;
+
         if (globalHeadingMode === "tangential") {
           if (isChained) {
             // Chained (with or without global override): race toward the ABSOLUTE geometric
@@ -1122,9 +1140,6 @@ export function calculatePathTime(
             // it would compare 90° vs 89°,88°... instead of 90° vs 45°,44°... etc.
             const cps = [prevPoint, ...line.controlPoints, line.endPoint];
             const isReverse = (line.endPoint as any).reverse;
-            const maxAngVelDegPerSec =
-              Math.max(safeSettings.aVelocity, 0.001) * (180 / Math.PI);
-            const eps = 0.005;
             let simH = currentHeading;
             for (let i = 1; i <= samples; i++) {
               const t = i / samples;
@@ -1285,9 +1300,21 @@ export function calculatePathTime(
                if (activeSeg.reverse) deg += 180;
                targetHeading = unwrapAngle(deg, simHeading);
             } else if (activeSeg.heading === "tangential") {
-               let deg = analysis.steps[Math.min(i-1, analysis.steps.length-1)].heading;
-               if (activeSeg.reverse) deg += 180;
-               targetHeading = unwrapAngle(deg, simHeading);
+               const tA = Math.max(0, localRatio - eps);
+               const tB = Math.min(1, localRatio + eps);
+               const posA = getCurvePoint(tA, cps);
+               const posB = getCurvePoint(tB, cps);
+               const dx = posB.x - posA.x;
+               const dy = posB.y - posA.y;
+               if (Math.abs(dx) < 1e-9 && Math.abs(dy) < 1e-9) {
+                  targetHeading = simHeading;
+               } else {
+                  const absTangentDeg = Math.atan2(dy, dx) * (180 / Math.PI);
+                  targetHeading = unwrapAngle(
+                    activeSeg.reverse ? absTangentDeg + 180 : absTangentDeg,
+                    simHeading,
+                  );
+               }
             } else if (activeSeg.heading === "linear") {
                let sDeg = activeSeg.startDeg ?? 0;
                let eDeg = activeSeg.endDeg ?? 0;
@@ -1312,21 +1339,28 @@ export function calculatePathTime(
             } else if (activeSeg.heading === "facingPoint") {
                const targetX = activeSeg.targetX || 0;
                const targetY = activeSeg.targetY || 0;
-               const pos = getCurvePoint(t, cps);
-               let angle = Math.atan2(targetY - pos.y, targetX - pos.x) * (180 / Math.PI);
+                const pos = getCurvePoint(localRatio, cps);
+                let angle =
+                  Math.atan2(targetY - pos.y, targetX - pos.x) * (180 / Math.PI);
                if (activeSeg.reverse) angle += 180;
                targetHeading = unwrapAngle(angle, simHeading);
             }
 
             const dt = motionProfile[i] - motionProfile[i-1];
-            const catchUpRequired = Math.abs(targetHeading - simHeading);
-            const stepPhysicalTime = calculateRotationTime(catchUpRequired, safeSettings);
             let nextHeading;
-            if (stepPhysicalTime > 0 && dt < stepPhysicalTime) {
-                const ratio = dt / stepPhysicalTime;
-                nextHeading = simHeading + (targetHeading - simHeading) * Math.min(1.0, ratio);
+
+            if (activeSeg.heading === "tangential") {
+                const maxRot = maxAngVelDegPerSec * dt;
+                nextHeading = simHeading + Math.max(-maxRot, Math.min(maxRot, targetHeading - simHeading));
             } else {
-                nextHeading = targetHeading;
+                const catchUpRequired = Math.abs(targetHeading - simHeading);
+                const stepPhysicalTime = calculateRotationTime(catchUpRequired, safeSettings);
+                if (stepPhysicalTime > 0 && dt < stepPhysicalTime) {
+                    const ratio = dt / stepPhysicalTime;
+                    nextHeading = simHeading + (targetHeading - simHeading) * Math.min(1.0, ratio);
+                } else {
+                    nextHeading = targetHeading;
+                }
             }
             simHeading = nextHeading;
             headingProfile.push(simHeading);

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -639,6 +639,57 @@ export function calculatePathTime(
       lineById.set(ln.id, ln);
     });
 
+    const globalChainMeta = new Map<string, {
+      rootLine: Line,
+      chainTotalLength: number,
+      distanceBefore: number,
+    }>();
+
+    let tempLastPoint = lastPoint;
+    let currentChainLength = 0;
+    let currentRootLine: Line | null = null;
+
+    seq.forEach((item, idx) => {
+      if (item.kind !== "path") return;
+      const line = lineById.get((item as any).lineId);
+      if (!line || !line.endPoint) return;
+      
+      const prevItem = idx > 0 ? seq[idx - 1] : null;
+      const isChained = !!(
+         prevItem &&
+         prevItem.kind === "path" &&
+         ((item as any).isChain === true || line.isChain === true)
+      );
+
+      const analysis = analyzePathSegment(
+         tempLastPoint, 
+         line.controlPoints as any, 
+         line.endPoint as any, 
+         50, 
+         0
+      );
+
+      if (!isChained) {
+         currentRootLine = line;
+         currentChainLength = 0;
+      }
+      
+      if (currentRootLine) {
+         globalChainMeta.set(line.id!, {
+            rootLine: currentRootLine,
+            chainTotalLength: 0, 
+            distanceBefore: currentChainLength
+         });
+         currentChainLength += analysis.length;
+         for (const meta of globalChainMeta.values()) {
+            if (meta.rootLine === currentRootLine) {
+               meta.chainTotalLength = currentChainLength;
+            }
+         }
+      }
+      tempLastPoint = line.endPoint;
+    });
+
     seq.forEach((item, idx) => {
       // Registry Check
       const action = actionRegistry.get(item.kind);
@@ -831,7 +882,13 @@ export function calculatePathTime(
       let endHeadingRaw = getLineEndHeading(line, prevPoint);
       let endHeading = endHeadingRaw;
 
-      if (line.endPoint.heading === "tangential") {
+      // Resolve global chain heading override for endHeading/rotation calculation
+      const _chainMeta = globalChainMeta.get(line.id!);
+      const _rootLine = _chainMeta?.rootLine;
+      const _isGlobalOverride = !!(_rootLine?.globalHeading && _rootLine.globalHeading !== 'none');
+      const _effectiveHeading = _isGlobalOverride ? _rootLine.globalHeading : line.endPoint.heading;
+
+      if (_effectiveHeading === "tangential") {
         if (isChained) {
           endHeading = unwrapAngle(endHeadingRaw, currentHeading);
           rotationRequired = Math.abs(endHeading - currentHeading);
@@ -839,22 +896,20 @@ export function calculatePathTime(
           endHeading = currentHeading + analysis.netRotation;
           rotationRequired = analysis.tangentRotation;
         }
-      } else if (line.endPoint.heading === "constant") {
-        // Constant heading, apply reverse by flipping 180°
-        const constDeg = line.endPoint.reverse
-          ? line.endPoint.degrees + 180
-          : line.endPoint.degrees;
-        endHeading = unwrapAngle(constDeg, currentHeading);
+      } else if (_effectiveHeading === "constant") {
+        const constDeg = _isGlobalOverride ? _rootLine.globalDegrees || 0 : (line.endPoint as any).degrees || 0;
+        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
+        const finalDeg = rev ? constDeg + 180 : constDeg;
+        endHeading = unwrapAngle(finalDeg, currentHeading);
         rotationRequired = Math.abs(endHeading - currentHeading);
-      } else if (line.endPoint.heading === "linear") {
-        const startDeg = line.endPoint.startDeg;
-        const endDeg = line.endPoint.endDeg;
-        if (line.endPoint.reverse) {
-          // Use the longer arc: invert the rotation direction
+      } else if (_effectiveHeading === "linear") {
+        const startDeg = _isGlobalOverride ? _rootLine.globalStartDeg || 0 : (line.endPoint as any).startDeg || 0;
+        const endDeg = _isGlobalOverride ? _rootLine.globalEndDeg || 0 : (line.endPoint as any).endDeg || 0;
+        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
+        if (rev) {
           const shortDiff = endDeg - startDeg;
           const normalizedShort = ((shortDiff % 360) + 360) % 360;
-          const longDiff =
-            normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+          const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
           endHeading = unwrapAngle(startDeg + longDiff, currentHeading);
           rotationRequired = Math.abs(longDiff);
         } else {
@@ -862,19 +917,63 @@ export function calculatePathTime(
           const startUnwound = unwrapAngle(startDeg, currentHeading);
           rotationRequired = Math.abs(endHeading - startUnwound);
         }
-      } else if (line.endPoint.heading === "facingPoint") {
-        // FacingPoint: Robot rotates to always face the fixed target point.
-        const targetX = (line.endPoint as any).targetX || 0;
-        const targetY = (line.endPoint as any).targetY || 0;
-        // Compute the angle from the endpoint to the target
+      } else if (_effectiveHeading === "facingPoint") {
+        const targetX = _isGlobalOverride ? _rootLine.globalTargetX || 0 : (line.endPoint as any).targetX || 0;
+        const targetY = _isGlobalOverride ? _rootLine.globalTargetY || 0 : (line.endPoint as any).targetY || 0;
+        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
         const facingAngle =
-          Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) *
-          (180 / Math.PI);
-        const finalFacing = (line.endPoint as any).reverse
-          ? facingAngle + 180
-          : facingAngle;
+          Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) * (180 / Math.PI);
+        const finalFacing = rev ? facingAngle + 180 : facingAngle;
         endHeading = unwrapAngle(finalFacing, currentHeading);
         rotationRequired = Math.abs(endHeading - currentHeading);
+      } else if (_effectiveHeading === "piecewise") {
+        let targetHeading = currentHeading;
+        const _cTotalLen = _chainMeta ? _chainMeta.chainTotalLength : length;
+        const _cDistBefore = _chainMeta ? _chainMeta.distanceBefore : 0;
+        // Use globalT=1.0 for the end of this segment
+        const segments = _isGlobalOverride ? _rootLine.globalSegments || [] : line.endPoint.segments || [];
+        const globalT = _isGlobalOverride && _cTotalLen > 0
+          ? (_cDistBefore + length) / _cTotalLen
+          : 1.0;
+        let activeSeg = null;
+        for (const seg of segments) {
+          if (globalT >= seg.tStart && globalT <= seg.tEnd) {
+            activeSeg = seg;
+            break;
+          }
+        }
+        if (!activeSeg && segments.length > 0) activeSeg = segments[segments.length - 1];
+
+        if (activeSeg) {
+           if (activeSeg.heading === "constant") {
+              let deg = activeSeg.degrees ?? 0;
+              if (activeSeg.reverse) deg += 180;
+              targetHeading = unwrapAngle(deg, currentHeading);
+           } else if (activeSeg.heading === "tangential") {
+              targetHeading = unwrapAngle(endHeadingRaw, currentHeading);
+           } else if (activeSeg.heading === "linear") {
+              let deg = activeSeg.endDeg ?? 0;
+              if (activeSeg.reverse) {
+                 const sDeg = activeSeg.startDeg ?? 0;
+                 const eDeg = activeSeg.endDeg ?? 0;
+                 const shortDiff = eDeg - sDeg;
+                 const normalizedShort = ((shortDiff % 360) + 360) % 360;
+                 const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+                 const startUnwound = unwrapAngle(sDeg, currentHeading);
+                 targetHeading = startUnwound + longDiff;
+              } else {
+                 targetHeading = unwrapAngle(deg, currentHeading);
+              }
+           } else if (activeSeg.heading === "facingPoint") {
+              const targetX = activeSeg.targetX || 0;
+              const targetY = activeSeg.targetY || 0;
+              let angle = Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) * (180 / Math.PI);
+              if (activeSeg.reverse) angle += 180;
+              targetHeading = unwrapAngle(angle, currentHeading);
+           }
+        }
+        endHeading = targetHeading;
+        rotationRequired = 0;
       }
 
       if (!Number.isFinite(endHeading)) endHeading = currentHeading;
@@ -904,26 +1003,49 @@ export function calculatePathTime(
         headingProfile = [currentHeading];
         const samples = analysis.steps.length;
 
-        if (line.endPoint.heading === "tangential") {
-          if (isChained) {
+        const chainMeta = globalChainMeta.get(line.id!);
+        const rootLine = chainMeta?.rootLine;
+        const isGlobalOverride = !!(rootLine?.globalHeading && rootLine.globalHeading !== 'none');
+        const globalHeadingMode = isGlobalOverride ? rootLine.globalHeading : line.endPoint.heading;
+        const cTotalLen = chainMeta ? chainMeta.chainTotalLength : length;
+        const cDistBefore = chainMeta ? chainMeta.distanceBefore : 0;
+
+        if (globalHeadingMode === "tangential") {
+          if (isChained && !isGlobalOverride) {
+            // Continuously track the path tangent at each step with physics-limited catchup.
+            // This is more accurate than interpolating to a fixed endHeading: the robot
+            // always tries to face the current tangent direction rather than the final one.
+            let simH = currentHeading;
             for (let i = 1; i <= samples; i++) {
-              const stepTime = motionProfile[i];
-              // ratio based on physical rotation time, cap at 1.0 (finished turn)
-              const ratio =
-                physicalRotationTime > 0
-                  ? Math.min(1.0, stepTime / physicalRotationTime)
-                  : 1.0;
-              headingProfile.push(
-                currentHeading + (endHeading - currentHeading) * ratio,
-              );
+              const stepTangent = analysis.steps[Math.min(i - 1, analysis.steps.length - 1)].heading;
+              const wTarget = unwrapAngle(stepTangent, simH);
+              const dt = (motionProfile[i] ?? motionProfile[motionProfile.length - 1])
+                       - (motionProfile[i - 1] ?? 0);
+              const catchUp = Math.abs(wTarget - simH);
+              const stepPhyTime = calculateRotationTime(catchUp, safeSettings);
+              let next: number;
+              if (stepPhyTime > 0 && dt < stepPhyTime) {
+                next = simH + (wTarget - simH) * (dt / stepPhyTime);
+              } else {
+                next = wTarget;
+              }
+              simH = next;
+              headingProfile.push(simH);
             }
           } else {
+            // Non-chained or global override: just push the raw tangent steps.
+            // For global override the re-unwrap pass will stitch continuity.
             for (const step of analysis.steps) {
               headingProfile.push(step.heading);
             }
           }
-        } else if (line.endPoint.heading === "constant") {
-          if (isChained) {
+        } else if (globalHeadingMode === "constant") {
+          const targetConstDeg = isGlobalOverride ? rootLine.globalDegrees || 0 : (line.endPoint as any).degrees || 0;
+          const isReverse = isGlobalOverride ? rootLine.globalReverse : (line.endPoint as any).reverse;
+          const finalTargetDeg = isReverse ? targetConstDeg + 180 : targetConstDeg;
+          const targetConstHeading = unwrapAngle(finalTargetDeg, currentHeading);
+
+          if (isChained && !isGlobalOverride) {
             for (let i = 1; i <= samples; i++) {
               const stepTime = motionProfile[i];
               const ratio =
@@ -936,13 +1058,15 @@ export function calculatePathTime(
             }
           } else {
             for (let i = 1; i <= samples; i++) {
-              headingProfile.push(endHeading); // Instantly snapped or constant
+              headingProfile.push(targetConstHeading);
             }
           }
-        } else if (line.endPoint.heading === "linear") {
-          const startDeg = line.endPoint.startDeg;
-          const endDeg = line.endPoint.endDeg;
-          if (line.endPoint.reverse) {
+        } else if (globalHeadingMode === "linear") {
+          const startDeg = isGlobalOverride ? rootLine.globalStartDeg || 0 : (line.endPoint as any).startDeg || 0;
+          const endDeg = isGlobalOverride ? rootLine.globalEndDeg || 0 : (line.endPoint as any).endDeg || 0;
+          const isReverse = isGlobalOverride ? rootLine.globalReverse : (line.endPoint as any).reverse;
+
+          if (isReverse) {
             const shortDiff = endDeg - startDeg;
             const normalizedShort = ((shortDiff % 360) + 360) % 360;
             const longDiff =
@@ -950,7 +1074,10 @@ export function calculatePathTime(
             const targetStartHeading = unwrapAngle(startDeg, currentHeading);
 
             for (let i = 1; i <= samples; i++) {
-              if (isChained) {
+              if (isGlobalOverride) {
+                 const t = cTotalLen > 0 ? (cDistBefore + (i / samples) * length) / cTotalLen : (i / samples);
+                 headingProfile.push(targetStartHeading + longDiff * t);
+              } else if (isChained) {
                 const stepTime = motionProfile[i];
                 const ratio =
                   physicalRotationTime > 0
@@ -961,15 +1088,18 @@ export function calculatePathTime(
                 );
               } else {
                 const ratio = i / samples;
-                const interpolatedHeading =
-                  targetStartHeading + longDiff * ratio;
+                const interpolatedHeading = targetStartHeading + longDiff * ratio;
                 headingProfile!.push(interpolatedHeading);
               }
             }
           } else {
             const startUnwound = unwrapAngle(startDeg, currentHeading);
+            const unwrappedEnd = unwrapAngle(endDeg, startUnwound);
             for (let i = 1; i <= samples; i++) {
-              if (isChained) {
+              if (isGlobalOverride) {
+                 const t = cTotalLen > 0 ? (cDistBefore + (i / samples) * length) / cTotalLen : (i / samples);
+                 headingProfile.push(startUnwound + (unwrappedEnd - startUnwound) * t);
+              } else if (isChained) {
                 const stepTime = motionProfile[i];
                 const ratio =
                   physicalRotationTime > 0
@@ -981,46 +1111,145 @@ export function calculatePathTime(
               } else {
                 const ratio = i / samples;
                 const interpolatedHeading =
-                  startUnwound + (endHeading - startUnwound) * ratio;
+                  startUnwound + (unwrappedEnd - startUnwound) * ratio;
                 headingProfile!.push(interpolatedHeading);
               }
             }
           }
-        } else if (line.endPoint.heading === "facingPoint") {
+
+        } else if (globalHeadingMode === "facingPoint") {
           const cps = [prevPoint, ...line.controlPoints, line.endPoint];
-          const targetX = (line.endPoint as any).targetX || 0;
-          const targetY = (line.endPoint as any).targetY || 0;
+          const targetX = isGlobalOverride ? rootLine.globalTargetX || 0 : (line.endPoint as any).targetX || 0;
+          const targetY = isGlobalOverride ? rootLine.globalTargetY || 0 : (line.endPoint as any).targetY || 0;
+          const isReverse = isGlobalOverride ? rootLine.globalReverse : (line.endPoint as any).reverse;
 
           for (let i = 1; i <= samples; i++) {
             const t = i / samples;
             const pos = getCurvePoint(t, cps);
             let angle =
               Math.atan2(targetY - pos.y, targetX - pos.x) * (180 / Math.PI);
-            if ((line.endPoint as any).reverse) angle += 180;
+            if (isReverse) angle += 180;
             const targetHeading = unwrapAngle(
               angle,
               headingProfile[headingProfile.length - 1],
             );
 
-            if (isChained) {
-              const stepTime = motionProfile[i];
-              // For facing point when chained, we interpolate towards the active target heading
-              // based on physical rotation time, trying to "catch up"
-              const catchUpRequired = Math.abs(targetHeading - currentHeading);
-              const stepPhysicalTime = calculateRotationTime(
-                catchUpRequired,
-                safeSettings,
+            if (isGlobalOverride) {
+              // Global override: instantly track the ideal facing angle (no rotation lag).
+              headingProfile.push(targetHeading);
+            } else if (isChained) {
+              // Continuously track the facing angle at each step with physics-limited catchup.
+              // Use a running simH (the previous headingProfile entry) so catchup builds
+              // on actual achieved heading rather than always anchoring to currentHeading.
+              const prevH = headingProfile[headingProfile.length - 1];
+              const wTarget = unwrapAngle(
+                Math.atan2(targetY - getCurvePoint(i / samples, cps).y,
+                           targetX - getCurvePoint(i / samples, cps).x) * (180 / Math.PI)
+                + (isReverse ? 180 : 0),
+                prevH,
               );
-              const ratio =
-                stepPhysicalTime > 0
-                  ? Math.min(1.0, stepTime / stepPhysicalTime)
-                  : 1.0;
-              headingProfile.push(
-                currentHeading + (targetHeading - currentHeading) * ratio,
-              );
+              const dt = (motionProfile[i] ?? motionProfile[motionProfile.length - 1])
+                       - (motionProfile[i - 1] ?? 0);
+              const catchUp = Math.abs(wTarget - prevH);
+              const stepPhyTime = calculateRotationTime(catchUp, safeSettings);
+              let next: number;
+              if (stepPhyTime > 0 && dt < stepPhyTime) {
+                next = prevH + (wTarget - prevH) * (dt / stepPhyTime);
+              } else {
+                next = wTarget;
+              }
+              headingProfile.push(next);
             } else {
               headingProfile.push(targetHeading);
             }
+          }
+        } else if (globalHeadingMode === "piecewise") {
+          const cps = [prevPoint, ...line.controlPoints, line.endPoint];
+          const segments = isGlobalOverride ? rootLine.globalSegments || [] : line.endPoint.segments || [];
+          let simHeading = currentHeading;
+          
+          for (let i = 1; i <= samples; i++) {
+            const localRatio = i / samples;
+            const t = isGlobalOverride && cTotalLen > 0
+               ? (cDistBefore + localRatio * length) / cTotalLen
+               : localRatio;
+
+            let activeSeg = null;
+            for (const seg of segments) {
+               if (t >= seg.tStart && t <= seg.tEnd) {
+                 activeSeg = seg;
+                 break;
+               }
+            }
+            if (!activeSeg) {
+               headingProfile.push(simHeading);
+               continue;
+            }
+
+            let targetHeading = simHeading;
+            if (activeSeg.heading === "constant") {
+               let deg = activeSeg.degrees ?? 0;
+               if (activeSeg.reverse) deg += 180;
+               targetHeading = unwrapAngle(deg, simHeading);
+            } else if (activeSeg.heading === "tangential") {
+               let deg = analysis.steps[Math.min(i-1, analysis.steps.length-1)].heading;
+               if (activeSeg.reverse) deg += 180;
+               targetHeading = unwrapAngle(deg, simHeading);
+            } else if (activeSeg.heading === "linear") {
+               let sDeg = activeSeg.startDeg ?? 0;
+               let eDeg = activeSeg.endDeg ?? 0;
+               let localT = 0;
+               if (activeSeg.tEnd > activeSeg.tStart) {
+                  localT = (t - activeSeg.tStart) / (activeSeg.tEnd - activeSeg.tStart);
+               }
+               if (localT < 0) localT = 0;
+               if (localT > 1) localT = 1;
+               
+               if (activeSeg.reverse) {
+                  const shortDiff = eDeg - sDeg;
+                  const normalizedShort = ((shortDiff % 360) + 360) % 360;
+                  const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+                  const startUnwound = unwrapAngle(sDeg, simHeading);
+                  targetHeading = startUnwound + longDiff * localT;
+               } else {
+                  let endUnwound = unwrapAngle(eDeg, simHeading);
+                  let startUnwound = unwrapAngle(sDeg, simHeading);
+                  targetHeading = startUnwound + (endUnwound - startUnwound) * localT;
+               }
+            } else if (activeSeg.heading === "facingPoint") {
+               const targetX = activeSeg.targetX || 0;
+               const targetY = activeSeg.targetY || 0;
+               const pos = getCurvePoint(t, cps);
+               let angle = Math.atan2(targetY - pos.y, targetX - pos.x) * (180 / Math.PI);
+               if (activeSeg.reverse) angle += 180;
+               targetHeading = unwrapAngle(angle, simHeading);
+            }
+
+            const dt = motionProfile[i] - motionProfile[i-1];
+            const catchUpRequired = Math.abs(targetHeading - simHeading);
+            const stepPhysicalTime = calculateRotationTime(catchUpRequired, safeSettings);
+            let nextHeading;
+            if (stepPhysicalTime > 0 && dt < stepPhysicalTime) {
+                const ratio = dt / stepPhysicalTime;
+                nextHeading = simHeading + (targetHeading - simHeading) * Math.min(1.0, ratio);
+            } else {
+                nextHeading = targetHeading;
+            }
+            simHeading = nextHeading;
+            headingProfile.push(simHeading);
+          }
+        }
+
+        // Re-unwrap the heading profile so no two adjacent entries differ by > 180°.
+        // This prevents teleport snaps both within a segment and across segment boundaries.
+        if (headingProfile && headingProfile.length > 1) {
+          for (let k = 1; k < headingProfile.length; k++) {
+            const prev = headingProfile[k - 1];
+            let curr = headingProfile[k];
+            // Bring curr within 180° of prev
+            while (curr - prev > 180) curr -= 360;
+            while (curr - prev < -180) curr += 360;
+            headingProfile[k] = curr;
           }
         }
       }
@@ -1043,8 +1272,14 @@ export function calculatePathTime(
       });
       currentTime += segmentTime;
 
-      // Update state
-      currentHeading = endHeading;
+      // Update state: seed from actual last heading profile value if available
+      // so the next segment always continues from wherever we truly ended up
+      // (which can differ from endHeading when using global chain interpolation).
+      if (headingProfile && headingProfile.length > 0) {
+        currentHeading = headingProfile[headingProfile.length - 1];
+      } else {
+        currentHeading = endHeading;
+      }
       lastPoint = line.endPoint as Point;
     });
   };

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -1011,9 +1011,9 @@ export function calculatePathTime(
         const cDistBefore = chainMeta ? chainMeta.distanceBefore : 0;
 
         if (globalHeadingMode === "tangential") {
-          if (isChained && !isGlobalOverride) {
-            // Chained: race toward the ABSOLUTE geometric tangent of the curve at each
-            // sample, capped by max angular velocity * dt. We must use getCurvePoint
+          if (isChained) {
+            // Chained (with or without global override): race toward the ABSOLUTE geometric
+            // tangent of the curve at each sample, capped by max angular velocity * dt.
             // finite-difference here — analysis.steps[i].heading only tracks curvature
             // deltas added to currentHeading, NOT the path's true absolute tangent, so
             // it would compare 90° vs 89°,88°... instead of 90° vs 45°,44°... etc.
@@ -1061,7 +1061,7 @@ export function calculatePathTime(
           const finalTargetDeg = isReverse ? targetConstDeg + 180 : targetConstDeg;
           const targetConstHeading = unwrapAngle(finalTargetDeg, currentHeading);
 
-          if (isChained && !isGlobalOverride) {
+          if (isChained) {
             for (let i = 1; i <= samples; i++) {
               const stepTime = motionProfile[i];
               const ratio =

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -570,6 +570,74 @@ function calculateMotionProfileDetailed(
   return { totalTime, profile, velocityProfile };
 }
 
+export function calculateGlobalChainMeta(
+  seq: SequenceItem[],
+  lines: Line[],
+  startPoint: Point,
+) {
+  const lineById = new Map<string, Line>();
+  lines.forEach((ln) => {
+    if (!ln.id) ln.id = `line-${Math.random().toString(36).slice(2)}`;
+    lineById.set(ln.id, ln);
+  });
+
+  const meta = new Map<
+    string,
+    {
+      rootLine: Line;
+      chainTotalLength: number;
+      distanceBefore: number;
+    }
+  >();
+
+  let tempLastPoint = startPoint;
+  let currentChainLength = 0;
+  let currentRootLine: Line | null = null;
+
+  seq.forEach((item, idx) => {
+    if (item.kind !== "path") return;
+    const line = lineById.get((item as any).lineId);
+    if (!line || !line.endPoint) return;
+
+    const prevItem = idx > 0 ? seq[idx - 1] : null;
+    const isChained = !!(
+      prevItem &&
+      prevItem.kind === "path" &&
+      ((item as any).isChain === true || line.isChain === true)
+    );
+
+    const analysis = analyzePathSegment(
+      tempLastPoint,
+      line.controlPoints as any,
+      line.endPoint as any,
+      50,
+      0,
+    );
+
+    if (!isChained) {
+      currentRootLine = line;
+      currentChainLength = 0;
+    }
+
+    if (currentRootLine) {
+      meta.set(line.id!, {
+        rootLine: currentRootLine,
+        chainTotalLength: 0,
+        distanceBefore: currentChainLength,
+      });
+      currentChainLength += analysis.length;
+      for (const m of meta.values()) {
+        if (m.rootLine === currentRootLine) {
+          m.chainTotalLength = currentChainLength;
+        }
+      }
+    }
+    tempLastPoint = line.endPoint;
+  });
+
+  return meta;
+}
+
 export function calculatePathTime(
   startPoint: Point,
   lines: Line[],
@@ -639,56 +707,7 @@ export function calculatePathTime(
       lineById.set(ln.id, ln);
     });
 
-    const globalChainMeta = new Map<string, {
-      rootLine: Line,
-      chainTotalLength: number,
-      distanceBefore: number,
-    }>();
-
-    let tempLastPoint = lastPoint;
-    let currentChainLength = 0;
-    let currentRootLine: Line | null = null;
-
-    seq.forEach((item, idx) => {
-      if (item.kind !== "path") return;
-      const line = lineById.get((item as any).lineId);
-      if (!line || !line.endPoint) return;
-      
-      const prevItem = idx > 0 ? seq[idx - 1] : null;
-      const isChained = !!(
-         prevItem &&
-         prevItem.kind === "path" &&
-         ((item as any).isChain === true || line.isChain === true)
-      );
-
-      const analysis = analyzePathSegment(
-         tempLastPoint, 
-         line.controlPoints as any, 
-         line.endPoint as any, 
-         50, 
-         0
-      );
-
-      if (!isChained) {
-         currentRootLine = line;
-         currentChainLength = 0;
-      }
-      
-      if (currentRootLine) {
-         globalChainMeta.set(line.id!, {
-            rootLine: currentRootLine,
-            chainTotalLength: 0, 
-            distanceBefore: currentChainLength
-         });
-         currentChainLength += analysis.length;
-         for (const meta of globalChainMeta.values()) {
-            if (meta.rootLine === currentRootLine) {
-               meta.chainTotalLength = currentChainLength;
-            }
-         }
-      }
-      tempLastPoint = line.endPoint;
-    });
+    const globalChainMeta = calculateGlobalChainMeta(seq, contextLines, lastPoint);
 
     seq.forEach((item, idx) => {
       // Registry Check
@@ -883,12 +902,16 @@ export function calculatePathTime(
       let endHeading = endHeadingRaw;
 
       // Resolve global chain heading override for endHeading/rotation calculation
-      const _chainMeta = globalChainMeta.get(line.id!);
-      const _rootLine = _chainMeta?.rootLine;
-      const _isGlobalOverride = !!(_rootLine?.globalHeading && _rootLine.globalHeading !== 'none');
-      const _effectiveHeading = _isGlobalOverride ? _rootLine.globalHeading : line.endPoint.heading;
+      const chainMeta = globalChainMeta.get(line.id!);
+      const rootLine = chainMeta?.rootLine;
+      const isGlobalOverride = !!(
+        rootLine?.globalHeading && rootLine.globalHeading !== "none"
+      );
+      const effectiveHeading = isGlobalOverride
+        ? rootLine.globalHeading!
+        : line.endPoint.heading;
 
-      if (_effectiveHeading === "tangential") {
+      if (effectiveHeading === "tangential") {
         if (isChained) {
           endHeading = unwrapAngle(endHeadingRaw, currentHeading);
           rotationRequired = Math.abs(endHeading - currentHeading);
@@ -896,20 +919,31 @@ export function calculatePathTime(
           endHeading = currentHeading + analysis.netRotation;
           rotationRequired = analysis.tangentRotation;
         }
-      } else if (_effectiveHeading === "constant") {
-        const constDeg = _isGlobalOverride ? _rootLine.globalDegrees || 0 : (line.endPoint as any).degrees || 0;
-        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
+      } else if (effectiveHeading === "constant") {
+        const constDeg = isGlobalOverride
+          ? rootLine.globalDegrees || 0
+          : (line.endPoint as any).degrees || 0;
+        const rev = isGlobalOverride
+          ? rootLine.globalReverse
+          : (line.endPoint as any).reverse;
         const finalDeg = rev ? constDeg + 180 : constDeg;
         endHeading = unwrapAngle(finalDeg, currentHeading);
         rotationRequired = Math.abs(endHeading - currentHeading);
-      } else if (_effectiveHeading === "linear") {
-        const startDeg = _isGlobalOverride ? _rootLine.globalStartDeg || 0 : (line.endPoint as any).startDeg || 0;
-        const endDeg = _isGlobalOverride ? _rootLine.globalEndDeg || 0 : (line.endPoint as any).endDeg || 0;
-        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
+      } else if (effectiveHeading === "linear") {
+        const startDeg = isGlobalOverride
+          ? rootLine.globalStartDeg || 0
+          : (line.endPoint as any).startDeg || 0;
+        const endDeg = isGlobalOverride
+          ? rootLine.globalEndDeg || 0
+          : (line.endPoint as any).endDeg || 0;
+        const rev = isGlobalOverride
+          ? rootLine.globalReverse
+          : (line.endPoint as any).reverse;
         if (rev) {
           const shortDiff = endDeg - startDeg;
           const normalizedShort = ((shortDiff % 360) + 360) % 360;
-          const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+          const longDiff =
+            normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
           endHeading = unwrapAngle(startDeg + longDiff, currentHeading);
           rotationRequired = Math.abs(longDiff);
         } else {
@@ -917,24 +951,34 @@ export function calculatePathTime(
           const startUnwound = unwrapAngle(startDeg, currentHeading);
           rotationRequired = Math.abs(endHeading - startUnwound);
         }
-      } else if (_effectiveHeading === "facingPoint") {
-        const targetX = _isGlobalOverride ? _rootLine.globalTargetX || 0 : (line.endPoint as any).targetX || 0;
-        const targetY = _isGlobalOverride ? _rootLine.globalTargetY || 0 : (line.endPoint as any).targetY || 0;
-        const rev = _isGlobalOverride ? _rootLine.globalReverse : (line.endPoint as any).reverse;
+      } else if (effectiveHeading === "facingPoint") {
+        const targetX = isGlobalOverride
+          ? rootLine.globalTargetX || 0
+          : (line.endPoint as any).targetX || 0;
+        const targetY = isGlobalOverride
+          ? rootLine.globalTargetY || 0
+          : (line.endPoint as any).targetY || 0;
+        const rev = isGlobalOverride
+          ? rootLine.globalReverse
+          : (line.endPoint as any).reverse;
         const facingAngle =
-          Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) * (180 / Math.PI);
+          Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) *
+          (180 / Math.PI);
         const finalFacing = rev ? facingAngle + 180 : facingAngle;
         endHeading = unwrapAngle(finalFacing, currentHeading);
         rotationRequired = Math.abs(endHeading - currentHeading);
-      } else if (_effectiveHeading === "piecewise") {
+      } else if (effectiveHeading === "piecewise") {
         let targetHeading = currentHeading;
-        const _cTotalLen = _chainMeta ? _chainMeta.chainTotalLength : length;
-        const _cDistBefore = _chainMeta ? _chainMeta.distanceBefore : 0;
+        const cTotalLen = chainMeta ? chainMeta.chainTotalLength : length;
+        const cDistBefore = chainMeta ? chainMeta.distanceBefore : 0;
         // Use globalT=1.0 for the end of this segment
-        const segments = _isGlobalOverride ? _rootLine.globalSegments || [] : line.endPoint.segments || [];
-        const globalT = _isGlobalOverride && _cTotalLen > 0
-          ? (_cDistBefore + length) / _cTotalLen
-          : 1.0;
+        const segments = isGlobalOverride
+          ? rootLine.globalSegments || []
+          : line.endPoint.segments || [];
+        const globalT =
+          isGlobalOverride && cTotalLen > 0
+            ? (cDistBefore + length) / cTotalLen
+            : 1.0;
         let activeSeg = null;
         for (const seg of segments) {
           if (globalT >= seg.tStart && globalT <= seg.tEnd) {
@@ -942,35 +986,39 @@ export function calculatePathTime(
             break;
           }
         }
-        if (!activeSeg && segments.length > 0) activeSeg = segments[segments.length - 1];
+        if (!activeSeg && segments.length > 0)
+          activeSeg = segments[segments.length - 1];
 
         if (activeSeg) {
-           if (activeSeg.heading === "constant") {
-              let deg = activeSeg.degrees ?? 0;
-              if (activeSeg.reverse) deg += 180;
+          if (activeSeg.heading === "constant") {
+            let deg = activeSeg.degrees ?? 0;
+            if (activeSeg.reverse) deg += 180;
+            targetHeading = unwrapAngle(deg, currentHeading);
+          } else if (activeSeg.heading === "tangential") {
+            targetHeading = unwrapAngle(endHeadingRaw, currentHeading);
+          } else if (activeSeg.heading === "linear") {
+            let deg = activeSeg.endDeg ?? 0;
+            if (activeSeg.reverse) {
+              const sDeg = activeSeg.startDeg ?? 0;
+              const eDeg = activeSeg.endDeg ?? 0;
+              const shortDiff = eDeg - sDeg;
+              const normalizedShort = ((shortDiff % 360) + 360) % 360;
+              const longDiff =
+                normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
+              const startUnwound = unwrapAngle(sDeg, currentHeading);
+              targetHeading = startUnwound + longDiff;
+            } else {
               targetHeading = unwrapAngle(deg, currentHeading);
-           } else if (activeSeg.heading === "tangential") {
-              targetHeading = unwrapAngle(endHeadingRaw, currentHeading);
-           } else if (activeSeg.heading === "linear") {
-              let deg = activeSeg.endDeg ?? 0;
-              if (activeSeg.reverse) {
-                 const sDeg = activeSeg.startDeg ?? 0;
-                 const eDeg = activeSeg.endDeg ?? 0;
-                 const shortDiff = eDeg - sDeg;
-                 const normalizedShort = ((shortDiff % 360) + 360) % 360;
-                 const longDiff = normalizedShort <= 180 ? normalizedShort - 360 : normalizedShort;
-                 const startUnwound = unwrapAngle(sDeg, currentHeading);
-                 targetHeading = startUnwound + longDiff;
-              } else {
-                 targetHeading = unwrapAngle(deg, currentHeading);
-              }
-           } else if (activeSeg.heading === "facingPoint") {
-              const targetX = activeSeg.targetX || 0;
-              const targetY = activeSeg.targetY || 0;
-              let angle = Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) * (180 / Math.PI);
-              if (activeSeg.reverse) angle += 180;
-              targetHeading = unwrapAngle(angle, currentHeading);
-           }
+            }
+          } else if (activeSeg.heading === "facingPoint") {
+            const targetX = activeSeg.targetX || 0;
+            const targetY = activeSeg.targetY || 0;
+            let angle =
+              Math.atan2(targetY - line.endPoint.y, targetX - line.endPoint.x) *
+              (180 / Math.PI);
+            if (activeSeg.reverse) angle += 180;
+            targetHeading = unwrapAngle(angle, currentHeading);
+          }
         }
         endHeading = targetHeading;
         rotationRequired = 0;
@@ -1003,10 +1051,9 @@ export function calculatePathTime(
         headingProfile = [currentHeading];
         const samples = analysis.steps.length;
 
-        const chainMeta = globalChainMeta.get(line.id!);
-        const rootLine = chainMeta?.rootLine;
-        const isGlobalOverride = !!(rootLine?.globalHeading && rootLine.globalHeading !== 'none');
-        const globalHeadingMode = isGlobalOverride ? rootLine.globalHeading : line.endPoint.heading;
+        const globalHeadingMode = isGlobalOverride
+          ? rootLine.globalHeading!
+          : line.endPoint.heading;
         const cTotalLen = chainMeta ? chainMeta.chainTotalLength : length;
         const cDistBefore = chainMeta ? chainMeta.distanceBefore : 0;
 
@@ -1248,18 +1295,23 @@ export function calculatePathTime(
 
       segmentTimes.push(segmentTime);
       const lineIndex = contextLines.findIndex((l) => l.id === line.id);
-      timeline.push({
-        type: "travel",
-        duration: segmentTime,
-        startTime: currentTime,
-        endTime: currentTime + segmentTime,
-        lineIndex,
-        line: line, // Pass direct reference
-        prevPoint: prevPoint as Point, // Pass direct reference
-        motionProfile: motionProfile,
-        velocityProfile: velocityProfile,
-        headingProfile: headingProfile,
-      });
+        timeline.push({
+          type: "travel",
+          duration: segmentTime,
+          startTime: currentTime,
+          endTime: currentTime + segmentTime,
+          lineIndex,
+          line: line, // Pass direct reference
+          prevPoint: prevPoint as Point, // Pass direct reference
+          motionProfile: motionProfile,
+          velocityProfile: velocityProfile,
+          headingProfile: headingProfile,
+          isGlobalOverride: isGlobalOverride,
+          rootLine: rootLine,
+          globalHeading: (isGlobalOverride
+            ? rootLine.globalHeading!
+            : line.endPoint.heading) as any,
+        });
       currentTime += segmentTime;
 
       // Update state: seed from actual last heading profile value if available

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -1012,29 +1012,45 @@ export function calculatePathTime(
 
         if (globalHeadingMode === "tangential") {
           if (isChained && !isGlobalOverride) {
-            // Continuously track the path tangent at each step with physics-limited catchup.
-            // This is more accurate than interpolating to a fixed endHeading: the robot
-            // always tries to face the current tangent direction rather than the final one.
+            // Chained: race toward the ABSOLUTE geometric tangent of the curve at each
+            // sample, capped by max angular velocity * dt. We must use getCurvePoint
+            // finite-difference here — analysis.steps[i].heading only tracks curvature
+            // deltas added to currentHeading, NOT the path's true absolute tangent, so
+            // it would compare 90° vs 89°,88°... instead of 90° vs 45°,44°... etc.
+            const cps = [prevPoint, ...line.controlPoints, line.endPoint];
+            const isReverse = (line.endPoint as any).reverse;
+            const maxAngVelDegPerSec =
+              Math.max(safeSettings.aVelocity, 0.001) * (180 / Math.PI);
+            const eps = 0.005;
             let simH = currentHeading;
             for (let i = 1; i <= samples; i++) {
-              const stepTangent = analysis.steps[Math.min(i - 1, analysis.steps.length - 1)].heading;
-              const wTarget = unwrapAngle(stepTangent, simH);
-              const dt = (motionProfile[i] ?? motionProfile[motionProfile.length - 1])
-                       - (motionProfile[i - 1] ?? 0);
-              const catchUp = Math.abs(wTarget - simH);
-              const stepPhyTime = calculateRotationTime(catchUp, safeSettings);
-              let next: number;
-              if (stepPhyTime > 0 && dt < stepPhyTime) {
-                next = simH + (wTarget - simH) * (dt / stepPhyTime);
+              const t = i / samples;
+              const tA = Math.max(0, t - eps);
+              const tB = Math.min(1, t + eps);
+              const posA = getCurvePoint(tA, cps);
+              const posB = getCurvePoint(tB, cps);
+              const dx = posB.x - posA.x;
+              const dy = posB.y - posA.y;
+              let idealTarget: number;
+              if (Math.abs(dx) < 1e-9 && Math.abs(dy) < 1e-9) {
+                idealTarget = simH; // degenerate — hold current
               } else {
-                next = wTarget;
+                const absTangentDeg = Math.atan2(dy, dx) * (180 / Math.PI);
+                idealTarget = unwrapAngle(
+                  isReverse ? absTangentDeg + 180 : absTangentDeg,
+                  simH,
+                );
               }
-              simH = next;
+              const dt =
+                (motionProfile[i] ?? motionProfile[motionProfile.length - 1]) -
+                (motionProfile[i - 1] ?? 0);
+              const maxRot = maxAngVelDegPerSec * dt;
+              simH += Math.max(-maxRot, Math.min(maxRot, idealTarget - simH));
               headingProfile.push(simH);
             }
           } else {
-            // Non-chained or global override: just push the raw tangent steps.
-            // For global override the re-unwrap pass will stitch continuity.
+            // Non-chained or global override: instantly track the geometric tangent.
+            // analyzePathSegment seeds from currentHeading so the profile is continuous.
             for (const step of analysis.steps) {
               headingProfile.push(step.heading);
             }
@@ -1123,45 +1139,19 @@ export function calculatePathTime(
           const targetY = isGlobalOverride ? rootLine.globalTargetY || 0 : (line.endPoint as any).targetY || 0;
           const isReverse = isGlobalOverride ? rootLine.globalReverse : (line.endPoint as any).reverse;
 
+          // Always track the ideal per-position facing angle continuously — no isChained
+          // branching. Using a running simH (last profile entry) ensures the angle is
+          // unwrapped relative to the most recently achieved heading, not an old anchor.
+          let simH = currentHeading;
           for (let i = 1; i <= samples; i++) {
             const t = i / samples;
             const pos = getCurvePoint(t, cps);
             let angle =
               Math.atan2(targetY - pos.y, targetX - pos.x) * (180 / Math.PI);
             if (isReverse) angle += 180;
-            const targetHeading = unwrapAngle(
-              angle,
-              headingProfile[headingProfile.length - 1],
-            );
-
-            if (isGlobalOverride) {
-              // Global override: instantly track the ideal facing angle (no rotation lag).
-              headingProfile.push(targetHeading);
-            } else if (isChained) {
-              // Continuously track the facing angle at each step with physics-limited catchup.
-              // Use a running simH (the previous headingProfile entry) so catchup builds
-              // on actual achieved heading rather than always anchoring to currentHeading.
-              const prevH = headingProfile[headingProfile.length - 1];
-              const wTarget = unwrapAngle(
-                Math.atan2(targetY - getCurvePoint(i / samples, cps).y,
-                           targetX - getCurvePoint(i / samples, cps).x) * (180 / Math.PI)
-                + (isReverse ? 180 : 0),
-                prevH,
-              );
-              const dt = (motionProfile[i] ?? motionProfile[motionProfile.length - 1])
-                       - (motionProfile[i - 1] ?? 0);
-              const catchUp = Math.abs(wTarget - prevH);
-              const stepPhyTime = calculateRotationTime(catchUp, safeSettings);
-              let next: number;
-              if (stepPhyTime > 0 && dt < stepPhyTime) {
-                next = prevH + (wTarget - prevH) * (dt / stepPhyTime);
-              } else {
-                next = wTarget;
-              }
-              headingProfile.push(next);
-            } else {
-              headingProfile.push(targetHeading);
-            }
+            const targetHeading = unwrapAngle(angle, simH);
+            simH = targetHeading;
+            headingProfile.push(simH);
           }
         } else if (globalHeadingMode === "piecewise") {
           const cps = [prevPoint, ...line.controlPoints, line.endPoint];

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -816,9 +816,16 @@ export function calculatePathTime(
         ((item as any).isChain === true || line.isChain === true)
       );
 
+      const chainMeta = globalChainMeta.get(line.id!);
+      const rootLine = chainMeta?.rootLine;
+
       // --- ROTATION CHECK (Initial Turn-to-Face or Wait) ---
       // Unwind requiredStartHeading relative to currentHeading
-      let requiredStartHeadingRaw = getLineStartHeading(line, prevPoint);
+      let requiredStartHeadingRaw = getLineStartHeading(
+        line,
+        prevPoint,
+        rootLine,
+      );
       // Unwind: find value closest to currentHeading
       let requiredStartHeading = unwrapAngle(
         requiredStartHeadingRaw,
@@ -898,7 +905,7 @@ export function calculatePathTime(
             if (prevLine) {
               // Start of the previous line isn't immediately available, but we can rough it from currentHeading
               // A better heuristic is to look at the immediate start angle of this line vs the inherited currentHeading
-              let thisStartHeading = getLineStartHeading(line, prevPoint);
+              let thisStartHeading = getLineStartHeading(line, prevPoint, rootLine);
               let diff = Math.abs(
                 getAngularDifference(currentHeading, thisStartHeading),
               );
@@ -918,6 +925,7 @@ export function calculatePathTime(
             let nextStartHeading = getLineStartHeading(
               nextLine,
               line.endPoint as Point,
+              globalChainMeta.get(nextLine.id!)?.rootLine,
             );
             let diff = Math.abs(
               getAngularDifference(thisEndHeading, nextStartHeading),
@@ -946,12 +954,12 @@ export function calculatePathTime(
       let rotationRequired = 0;
 
       // Determine End Heading (Unwound)
-      let endHeadingRaw = getLineEndHeading(line, prevPoint);
+      let endHeadingRaw = getLineEndHeading(line, prevPoint, rootLine);
       let endHeading = endHeadingRaw;
 
       // Resolve global chain heading override for endHeading/rotation calculation
-      const chainMeta = globalChainMeta.get(line.id!);
-      const rootLine = chainMeta?.rootLine;
+      // const chainMeta = globalChainMeta.get(line.id!);
+      // const rootLine = chainMeta?.rootLine;
       const isGlobalOverride = !!(
         rootLine?.globalHeading && rootLine.globalHeading !== "none"
       );


### PR DESCRIPTION
This pull request introduces significant enhancements to the robot heading controls and field editing experience, particularly by adding a new "piecewise" heading mode that allows for advanced, segment-based heading control. The update also improves the handling of chained path segments and refines the UI for editing and reordering heading segments.

**Piecewise Heading Controls & Segment Editing:**

* Added a new "piecewise" heading option in `HeadingControls.svelte`, enabling users to define multiple heading segments per endpoint, each with its own interpolation and transition points. This includes a collapsible UI for editing segments, controls for adding/removing transitions, and drag-and-drop or button-based reordering of segments. (`src/lib/components/HeadingControls.svelte`) [[1]](diffhunk://#diff-cd0cbc622977bb7fec31c5424609f9833367134e531b0164e9c0d71dbae9d9a3R10-R34) [[2]](diffhunk://#diff-cd0cbc622977bb7fec31c5424609f9833367134e531b0164e9c0d71dbae9d9a3R99-R232) [[3]](diffhunk://#diff-cd0cbc622977bb7fec31c5424609f9833367134e531b0164e9c0d71dbae9d9a3R259-R269) [[4]](diffhunk://#diff-cd0cbc622977bb7fec31c5424609f9833367134e531b0164e9c0d71dbae9d9a3R287-R293) [[5]](diffhunk://#diff-cd0cbc622977bb7fec31c5424609f9833367134e531b0164e9c0d71dbae9d9a3R505-R632)
* Updated the field rendering logic to support piecewise heading segments, ensuring correct display and manipulation of target points and segment endpoints, with proper handling for global vs. local heading overrides. (`src/lib/components/FieldRenderer.svelte`) [[1]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9L651-R730) [[2]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9L1041-R1126) [[3]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9L1077-R1175)

**Chained Path & Global Heading Handling:**

* Improved the logic for toggling path chaining in the waypoint table: when a chain is broken, any global heading overrides on the affected chain segment are cleared to prevent stale state. (`src/lib/components/WaypointTable.svelte`)
* Enhanced the field renderer to always compute the root of a chain when updating or displaying target points, ensuring global heading values are consistently applied or cleared as needed. (`src/lib/components/FieldRenderer.svelte`)

**General Improvements & Minor Fixes:**

* Updated utility imports and function signatures to support the new heading mode and ensure correct state propagation. (`src/lib/components/FieldRenderer.svelte`) [[1]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9R85) [[2]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9L1770-R1866) [[3]](diffhunk://#diff-8723da4d509a7b3b0f7e2e289e4835dc8e01e8d1e91a5f2506777dc04131c1b9L1833-R1929)
* Fixed a bug in keyboard shortcut settings reset to use the correct snapshot method for state cloning. (`src/lib/components/KeyboardShortcuts.svelte`)

These changes collectively provide a more powerful and flexible heading editing experience, especially for advanced robot path planning scenarios.