### PR TITLE
feat: add setting to lock field view zoom and drag

### DIFF
--- a/plugins/turtle.d.ts
+++ b/plugins/turtle.d.ts
@@ -316,6 +316,7 @@ interface Settings {
   autoExportEmbedPoseData?: boolean; // Embed pose data in the generated code
   telemetryImplementation?: "Standard" | "Dashboard" | "Panels" | "None";
   followRobot?: boolean;
+  lockFieldView?: boolean;
   coordinateSystem?: "Pedro" | "FTC";
   visualizerUnits?: "imperial" | "metric";
   codeUnits?: "imperial" | "metric";

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -88,6 +88,7 @@ export const DEFAULT_SETTINGS: Settings = {
   dismissedRatings: {},
   hasSeenOnboarding: false,
   gitIntegration: true,
+  lockFieldView: false,
   obstaclePresets: [
     {
       id: "preset-decode-2025",

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -15,6 +15,7 @@
     CodeIcon,
     DocumentIcon,
     StatsIcon,
+    LockIcon,
   } from "./components/icons";
 
   // Register default tabs; callable so plugin reloads can restore baseline tabs
@@ -691,6 +692,25 @@
       >
         <StatsIcon className="size-4" />
         Stats
+      </button>
+      <button
+        id="lock-btn"
+        onclick={() => {
+          settings.lockFieldView = !settings.lockFieldView;
+          settings = { ...settings };
+          if (settings.lockFieldView) {
+            import("../stores").then(({ fieldZoom, fieldPan }) => {
+              fieldZoom.set(1.0);
+              fieldPan.set({ x: 0, y: 0 });
+            });
+          }
+        }}
+        class="flex-none flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-purple-500 gap-2 shadow-sm {settings.lockFieldView ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800' : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:text-neutral-900 dark:hover:text-neutral-200'}"
+        title={settings.lockFieldView ? "Unlock Field View" : "Lock Field View"}
+        aria-label={settings.lockFieldView ? "Unlock Field View" : "Lock Field View"}
+      >
+        <LockIcon className="size-4 {settings.lockFieldView ? '' : 'opacity-50'}" />
+        Lock
       </button>
     </div>
 

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -15,7 +15,6 @@
     CodeIcon,
     DocumentIcon,
     StatsIcon,
-    LockIcon,
   } from "./components/icons";
 
   // Register default tabs; callable so plugin reloads can restore baseline tabs
@@ -692,25 +691,6 @@
       >
         <StatsIcon className="size-4" />
         Stats
-      </button>
-      <button
-        id="lock-btn"
-        onclick={() => {
-          settings.lockFieldView = !settings.lockFieldView;
-          settings = { ...settings };
-          if (settings.lockFieldView) {
-            import("../stores").then(({ fieldZoom, fieldPan }) => {
-              fieldZoom.set(1.0);
-              fieldPan.set({ x: 0, y: 0 });
-            });
-          }
-        }}
-        class="flex-none flex items-center justify-center px-4 py-2 text-sm font-semibold rounded-xl transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-purple-500 gap-2 shadow-sm {settings.lockFieldView ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-800' : 'bg-white dark:bg-neutral-800 text-neutral-600 dark:text-neutral-400 border border-neutral-200 dark:border-neutral-700 hover:bg-neutral-50 dark:hover:bg-neutral-700 hover:text-neutral-900 dark:hover:text-neutral-200'}"
-        title={settings.lockFieldView ? "Unlock Field View" : "Lock Field View"}
-        aria-label={settings.lockFieldView ? "Unlock Field View" : "Lock Field View"}
-      >
-        <LockIcon className="size-4 {settings.lockFieldView ? '' : 'opacity-50'}" />
-        Lock
       </button>
     </div>
 

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -228,7 +228,7 @@
   }
 
   function handleWheel(e: WheelEvent) {
-    if (!wrapperDiv) return;
+    if (!wrapperDiv || settings.lockFieldView) return;
     if (e.ctrlKey || e.metaKey) {
       followRobotStore.set(false);
       e.preventDefault();
@@ -1213,7 +1213,7 @@
             }
             multiDragOffsets.set(id, { x: ox - mouseX, y: oy - mouseY });
           });
-        } else {
+        } else if (!settings.lockFieldView) {
           // Start Panning
           isPanning = true;
           startPan = { x: evt.clientX, y: evt.clientY };
@@ -2506,50 +2506,52 @@
         </button>
         <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-0.5"></div>
       {/if}
-      <button
-        class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-        onclick={() => {
-          followRobotStore.set(false);
-          const step = computeZoomStep(zoom, 1);
-          const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
-          const focus = isMouseOverField
-            ? { x: x(currentMouseX), y: y(currentMouseY) }
-            : { x: width / 2, y: height / 2 };
-          zoomTo(newZoom, focus);
-        }}
-        aria-label="Zoom in"
-        title="Zoom In (Cmd/Ctrl + +)"
-      >
-        <PlusIcon className="w-4 h-4" />
-      </button>
-      <button
-        class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-        onclick={() => {
-          followRobotStore.set(false);
-          const step = computeZoomStep(zoom, -1);
-          const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
-          const focus = isMouseOverField
-            ? { x: x(currentMouseX), y: y(currentMouseY) }
-            : { x: width / 2, y: height / 2 };
-          zoomTo(newZoom, focus);
-        }}
-        aria-label="Zoom out"
-        title="Zoom Out (Cmd/Ctrl + -)"
-      >
-        <MinusIcon className="w-4 h-4" />
-      </button>
-      <button
-        class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-        onclick={() => {
-          followRobotStore.set(false);
-          fieldZoom.set(1.0);
-          fieldPan.set({ x: 0, y: 0 });
-        }}
-        aria-label="Reset zoom"
-        title="Reset Zoom (Cmd/Ctrl + 0)"
-      >
-        <ResetZoomIcon className="w-4 h-4" />
-      </button>
+      {#if !settings.lockFieldView}
+        <button
+          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+          onclick={() => {
+            followRobotStore.set(false);
+            const step = computeZoomStep(zoom, 1);
+            const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
+            const focus = isMouseOverField
+              ? { x: x(currentMouseX), y: y(currentMouseY) }
+              : { x: width / 2, y: height / 2 };
+            zoomTo(newZoom, focus);
+          }}
+          aria-label="Zoom in"
+          title="Zoom In (Cmd/Ctrl + +)"
+        >
+          <PlusIcon className="w-4 h-4" />
+        </button>
+        <button
+          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+          onclick={() => {
+            followRobotStore.set(false);
+            const step = computeZoomStep(zoom, -1);
+            const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
+            const focus = isMouseOverField
+              ? { x: x(currentMouseX), y: y(currentMouseY) }
+              : { x: width / 2, y: height / 2 };
+            zoomTo(newZoom, focus);
+          }}
+          aria-label="Zoom out"
+          title="Zoom Out (Cmd/Ctrl + -)"
+        >
+          <MinusIcon className="w-4 h-4" />
+        </button>
+        <button
+          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+          onclick={() => {
+            followRobotStore.set(false);
+            fieldZoom.set(1.0);
+            fieldPan.set({ x: 0, y: 0 });
+          }}
+          aria-label="Reset zoom"
+          title="Reset Zoom (Cmd/Ctrl + 0)"
+        >
+          <ResetZoomIcon className="w-4 h-4" />
+        </button>
+      {/if}
     </div>
   {/if}
 
@@ -2561,51 +2563,53 @@
       <div
         class="flex flex-col gap-1 bg-white/90 dark:bg-neutral-800/90 p-1.5 rounded-lg shadow-lg border border-neutral-200 dark:border-neutral-700 backdrop-blur-sm"
       >
-        <button
-          class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            const step = computeZoomStep(zoom, 1);
-            const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
-            const focus = isMouseOverField
-              ? { x: x(currentMouseX), y: y(currentMouseY) }
-              : { x: width / 2, y: height / 2 };
-            zoomTo(newZoom, focus);
-          }}
-          aria-label="Zoom in"
-          title="Zoom In"
-        >
-          <PlusIcon className="w-5 h-5" />
-        </button>
-        <button
-          class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            const step = computeZoomStep(zoom, -1);
-            const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
-            const focus = isMouseOverField
-              ? { x: x(currentMouseX), y: y(currentMouseY) }
-              : { x: width / 2, y: height / 2 };
-            zoomTo(newZoom, focus);
-          }}
-          aria-label="Zoom out"
-          title="Zoom Out"
-        >
-          <MinusIcon className="w-5 h-5" />
-        </button>
-        <button
-          class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            fieldZoom.set(1.0);
-            fieldPan.set({ x: 0, y: 0 });
-          }}
-          aria-label="Reset zoom"
-          title="Reset Zoom"
-        >
-          <ResetZoomIcon className="w-5 h-5" />
-        </button>
-        <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-0.5"></div>
+        {#if !settings.lockFieldView}
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              const step = computeZoomStep(zoom, 1);
+              const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
+              const focus = isMouseOverField
+                ? { x: x(currentMouseX), y: y(currentMouseY) }
+                : { x: width / 2, y: height / 2 };
+              zoomTo(newZoom, focus);
+            }}
+            aria-label="Zoom in"
+            title="Zoom In"
+          >
+            <PlusIcon className="w-5 h-5" />
+          </button>
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              const step = computeZoomStep(zoom, -1);
+              const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
+              const focus = isMouseOverField
+                ? { x: x(currentMouseX), y: y(currentMouseY) }
+                : { x: width / 2, y: height / 2 };
+              zoomTo(newZoom, focus);
+            }}
+            aria-label="Zoom out"
+            title="Zoom Out"
+          >
+            <MinusIcon className="w-5 h-5" />
+          </button>
+          <button
+            class="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              fieldZoom.set(1.0);
+              fieldPan.set({ x: 0, y: 0 });
+            }}
+            aria-label="Reset zoom"
+            title="Reset Zoom"
+          >
+            <ResetZoomIcon className="w-5 h-5" />
+          </button>
+          <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-0.5"></div>
+        {/if}
         <button
           class="w-8 h-8 flex items-center justify-center rounded hover:bg-red-100 dark:hover:bg-red-900/30 text-red-600 dark:text-red-400 transition-colors"
           onclick={() => isPresentationMode.set(false)}

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -2484,75 +2484,79 @@
       isObstructed={isObstructingHUD}
     />
 
-    <!-- Zoom Controls -->
-    <div
-      class="absolute bottom-2 right-2 flex flex-col gap-1 z-30 bg-white/80 dark:bg-neutral-800/80 p-1 rounded-md shadow-sm border border-neutral-200 dark:border-neutral-700 backdrop-blur-sm"
-    >
-      {#if isDirty}
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded transition-colors {isDiffMode
-            ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/50'
-            : 'hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200'}"
-          onclick={toggleDiff}
-          aria-label={isDiffMode ? "Exit Visual Diff" : "Toggle Visual Diff"}
-          title={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
-        >
-          {#if $isLoadingDiff}
-            <SpinnerIcon className="animate-spin w-4 h-4" />
-          {:else}
-            <!-- Diff Icon -->
-            <DocumentIcon className="w-4 h-4" />
+    {#if isDirty || !settings.lockFieldView}
+      <!-- Zoom Controls -->
+      <div
+        class="absolute bottom-2 right-2 flex flex-col gap-1 z-30 bg-white/80 dark:bg-neutral-800/80 p-1 rounded-md shadow-sm border border-neutral-200 dark:border-neutral-700 backdrop-blur-sm"
+      >
+        {#if isDirty}
+          <button
+            class="w-7 h-7 flex items-center justify-center rounded transition-colors {isDiffMode
+              ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/50'
+              : 'hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200'}"
+            onclick={toggleDiff}
+            aria-label={isDiffMode ? "Exit Visual Diff" : "Toggle Visual Diff"}
+            title={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
+          >
+            {#if $isLoadingDiff}
+              <SpinnerIcon className="animate-spin w-4 h-4" />
+            {:else}
+              <!-- Diff Icon -->
+              <DocumentIcon className="w-4 h-4" />
+            {/if}
+          </button>
+          {#if !settings.lockFieldView}
+            <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-0.5"></div>
           {/if}
-        </button>
-        <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-0.5"></div>
-      {/if}
-      {#if !settings.lockFieldView}
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            const step = computeZoomStep(zoom, 1);
-            const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
-            const focus = isMouseOverField
-              ? { x: x(currentMouseX), y: y(currentMouseY) }
-              : { x: width / 2, y: height / 2 };
-            zoomTo(newZoom, focus);
-          }}
-          aria-label="Zoom in"
-          title="Zoom In (Cmd/Ctrl + +)"
-        >
-          <PlusIcon className="w-4 h-4" />
-        </button>
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            const step = computeZoomStep(zoom, -1);
-            const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
-            const focus = isMouseOverField
-              ? { x: x(currentMouseX), y: y(currentMouseY) }
-              : { x: width / 2, y: height / 2 };
-            zoomTo(newZoom, focus);
-          }}
-          aria-label="Zoom out"
-          title="Zoom Out (Cmd/Ctrl + -)"
-        >
-          <MinusIcon className="w-4 h-4" />
-        </button>
-        <button
-          class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
-          onclick={() => {
-            followRobotStore.set(false);
-            fieldZoom.set(1.0);
-            fieldPan.set({ x: 0, y: 0 });
-          }}
-          aria-label="Reset zoom"
-          title="Reset Zoom (Cmd/Ctrl + 0)"
-        >
-          <ResetZoomIcon className="w-4 h-4" />
-        </button>
-      {/if}
-    </div>
+        {/if}
+        {#if !settings.lockFieldView}
+          <button
+            class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              const step = computeZoomStep(zoom, 1);
+              const newZoom = Math.min(5.0, Number((zoom + step).toFixed(2)));
+              const focus = isMouseOverField
+                ? { x: x(currentMouseX), y: y(currentMouseY) }
+                : { x: width / 2, y: height / 2 };
+              zoomTo(newZoom, focus);
+            }}
+            aria-label="Zoom in"
+            title="Zoom In (Cmd/Ctrl + +)"
+          >
+            <PlusIcon className="w-4 h-4" />
+          </button>
+          <button
+            class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              const step = computeZoomStep(zoom, -1);
+              const newZoom = Math.max(0.1, Number((zoom - step).toFixed(2)));
+              const focus = isMouseOverField
+                ? { x: x(currentMouseX), y: y(currentMouseY) }
+                : { x: width / 2, y: height / 2 };
+              zoomTo(newZoom, focus);
+            }}
+            aria-label="Zoom out"
+            title="Zoom Out (Cmd/Ctrl + -)"
+          >
+            <MinusIcon className="w-4 h-4" />
+          </button>
+          <button
+            class="w-7 h-7 flex items-center justify-center rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 transition-colors"
+            onclick={() => {
+              followRobotStore.set(false);
+              fieldZoom.set(1.0);
+              fieldPan.set({ x: 0, y: 0 });
+            }}
+            aria-label="Reset zoom"
+            title="Reset Zoom (Cmd/Ctrl + 0)"
+          >
+            <ResetZoomIcon className="w-4 h-4" />
+          </button>
+        {/if}
+      </div>
+    {/if}
   {/if}
 
   {#if $isPresentationMode}

--- a/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
@@ -407,6 +407,30 @@
   </SettingsItem>
 
   <SettingsItem
+    label="Lock Field View"
+    isModified={settings.lockFieldView !== DEFAULT_SETTINGS.lockFieldView}
+    onReset={() => {
+      settings.lockFieldView = DEFAULT_SETTINGS.lockFieldView;
+      settings = { ...settings };
+    }}
+    description="Lock the field view to prevent panning and zooming"
+    {searchQuery}
+    layout="row"
+    forId="lock-field-view"
+  >
+    <input
+      type="checkbox"
+      id="lock-field-view"
+      checked={settings.lockFieldView}
+      onchange={(e) => {
+        settings.lockFieldView = e.currentTarget.checked;
+        settings = { ...settings };
+      }}
+      class="w-5 h-5 rounded border-neutral-300 dark:border-neutral-600 text-emerald-500 focus:ring-2 focus:ring-emerald-500 cursor-pointer"
+    />
+  </SettingsItem>
+
+  <SettingsItem
     label="Follow Robot"
     isModified={settings.followRobot !== DEFAULT_SETTINGS.followRobot}
     onReset={() => {

--- a/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
@@ -7,8 +7,7 @@
   } from "../../../../config/defaults";
   import type { Settings, CustomFieldConfig } from "../../../../types/index";
   import { themesStore } from "../../../pluginsStore";
-  import { followRobotStore } from "../../../projectStore";
-  import * as ICONS from "../../icons";
+  import { followRobotStore } from "../../../projectStore";  import { fieldZoom, fieldPan } from "../../../../stores";  import * as ICONS from "../../icons";
   import CustomFieldWizard from "../../settings/CustomFieldWizard.svelte";
 
   interface Props {
@@ -48,6 +47,11 @@
       }
       settings = { ...settings };
     }
+  }
+
+  function resetFieldViewToDefault() {
+    fieldZoom.set(1.0);
+    fieldPan.set({ x: 0, y: 0 });
   }
 
   function handleCustomFieldSave(e: CustomEvent<CustomFieldConfig>) {
@@ -412,6 +416,7 @@
     onReset={() => {
       settings.lockFieldView = DEFAULT_SETTINGS.lockFieldView;
       settings = { ...settings };
+      resetFieldViewToDefault();
     }}
     description="Lock the field view to prevent panning and zooming"
     {searchQuery}
@@ -425,6 +430,7 @@
       onchange={(e) => {
         settings.lockFieldView = e.currentTarget.checked;
         settings = { ...settings };
+        resetFieldViewToDefault();
       }}
       class="w-5 h-5 rounded border-neutral-300 dark:border-neutral-600 text-emerald-500 focus:ring-2 focus:ring-emerald-500 cursor-pointer"
     />

--- a/src/lib/components/shortcuts/view.ts
+++ b/src/lib/components/shortcuts/view.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
 import { get } from "svelte/store";
-import { startPointStore, linesStore } from "../../projectStore";
+import { startPointStore, linesStore, settingsStore } from "../../projectStore";
 import {
   gridSize,
   fieldZoom,
@@ -29,7 +29,7 @@ export function cycleGridSizeReverse() {
 }
 
 export function modifyZoom(delta: number) {
-  if (isUIElementFocused()) return;
+  if (isUIElementFocused() || get(settingsStore).lockFieldView) return;
   fieldZoom.update((z) => {
     // Use adaptive step: when zooming in past 1x, speed up
     const step = computeZoomStep(z, Math.sign(delta));
@@ -39,7 +39,7 @@ export function modifyZoom(delta: number) {
 }
 
 export function resetZoom() {
-  if (isUIElementFocused()) return;
+  if (isUIElementFocused() || get(settingsStore).lockFieldView) return;
   fieldZoom.set(1.0);
   fieldPan.set({ x: 0, y: 0 });
 }
@@ -133,6 +133,6 @@ export function panToEnd(fieldRenderer: any) {
 }
 
 export function panView(dx: number, dy: number) {
-  if (isUIElementFocused()) return;
+  if (isUIElementFocused() || get(settingsStore).lockFieldView) return;
   fieldPan.update((p) => ({ x: p.x + dx, y: p.y + dy }));
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -309,6 +309,7 @@ export interface Settings {
   autoExportEmbedPoseData?: boolean; // Embed pose data in the generated code
   telemetryImplementation?: "Standard" | "Dashboard" | "Panels" | "None";
   followRobot?: boolean;
+  lockFieldView?: boolean;
   coordinateSystem?: "Pedro" | "FTC";
   visualizerUnits?: "imperial" | "metric";
   codeUnits?: "imperial" | "metric";


### PR DESCRIPTION
Adds a `lockFieldView` boolean setting to `Settings` and `DEFAULT_SETTINGS`.
Adds a toggle in the Interface Settings tab.
Hides the zoom UI controls in `FieldRenderer` when locked.
Disables panning and zooming via mouse/wheel and keyboard shortcuts when the view is locked.

---
*PR created automatically by Jules for task [5825956391852576157](https://jules.google.com/task/5825956391852576157) started by @Mallen220*