### PR TITLE
Refactor codebase formatting and eliminate DRY violations in math utils

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1212,9 +1212,7 @@
     let el = e.target as Element | null;
     while (el) {
       if (el.classList?.contains("wait-row")) return;
-      if (
-        el.id?.startsWith("wait-") || el.id?.startsWith("wait-event-")
-      )
+      if (el.id?.startsWith("wait-") || el.id?.startsWith("wait-event-"))
         return;
       el = el.parentElement;
     }
@@ -1428,10 +1426,7 @@
     }
   });
   run(() => {
-    if (
-      timePrediction?.timeline &&
-      (lines.length > 0 || sequence.length > 0)
-    ) {
+    if (timePrediction?.timeline && (lines.length > 0 || sequence.length > 0)) {
       // Calculate Global Time based on effective duration
       const globalTime = (percent / 100) * effectiveDuration;
 

--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -419,10 +419,7 @@
   });
   // collapse telemetry tab if user disabled it
   run(() => {
-    if (
-      activeTab === "telemetry" &&
-      settings?.showTelemetryTab === false
-    ) {
+    if (activeTab === "telemetry" && settings?.showTelemetryTab === false) {
       activeTab = "path";
     }
   });
@@ -519,8 +516,8 @@
       timeline.forEach((ev) => {
         if (ev.type === "travel") {
           const line = (ev as any).line || lines[ev.lineIndex as number];
-        if (line?.eventMarkers) {
-          line.eventMarkers.forEach((m: any) => {
+          if (line?.eventMarkers) {
+            line.eventMarkers.forEach((m: any) => {
               let timeOffset = 0;
               if (ev.motionProfile) {
                 const steps = ev.motionProfile.length - 1;

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -511,9 +511,7 @@
         const destPath = path.join(currentDirectory, fileName);
 
         // Check overwrite
-        if (
-          await electronAPI?.fileExists?.(destPath)
-        ) {
+        if (await electronAPI?.fileExists?.(destPath)) {
           if (
             !confirm(
               `File "${fileName}" already exists in "${path.basename(currentDirectory)}". Overwrite?`,

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -1944,7 +1944,7 @@
       (currentFile && $isUnsaved),
   );
   let dimmedIds = $derived($dimmedLinesStore);
-  
+
   let ctx = $derived<RenderContext>({
     x,
     y,
@@ -1965,9 +1965,7 @@
   // Animated facing-point line: drawn from current robot position to the facing target.
   // Only shown when the robot is actively driving on that facingPoint segment.
   // Rendered as SVG overlay to avoid clearing Two.js scene.
-  let facingLineElements = $derived(
-    generateFacingLineElements(lines, ctx),
-  );
+  let facingLineElements = $derived(generateFacingLineElements(lines, ctx));
   // Paths (Lines) - Standard
   let path = $derived(
     (() => {
@@ -2092,9 +2090,7 @@
     ),
   );
   // Shapes (Obstacles)
-  let shapeElements = $derived(
-    generateShapeElements(shapes, ctx),
-  );
+  let shapeElements = $derived(generateShapeElements(shapes, ctx));
   // Onion Layers
   // Rendered as SVG overlay to avoid clearing Two.js scene.
   let onionLayerElements = $derived(
@@ -2234,7 +2230,9 @@
     >
       {#each onionLayerElements as layer}
         <polygon
-          points={layer.corners.map((c: any) => `${x(c.x)},${y(c.y)}`).join(" ")}
+          points={layer.corners
+            .map((c: any) => `${x(c.x)},${y(c.y)}`)
+            .join(" ")}
           fill="none"
           stroke="#818cf8"
           stroke-width={uiLength(0.5)}

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -932,7 +932,8 @@
     const target = e.currentTarget || e.target;
     if (
       target instanceof HTMLInputElement &&
-      target.files && target.files.length > 0
+      target.files &&
+      target.files.length > 0
     ) {
       loadFile(e);
       target.value = "";

--- a/src/lib/components/renderer/FacingLineGenerator.ts
+++ b/src/lib/components/renderer/FacingLineGenerator.ts
@@ -1,8 +1,5 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
-import { 
-  type RenderContext, 
-  findActiveEvent 
-} from "./GeneratorUtils";
+import { type RenderContext, findActiveEvent } from "./GeneratorUtils";
 import type { Line } from "../../../types";
 
 export function generateFacingLineElements(lines: Line[], ctx: RenderContext) {

--- a/src/lib/components/renderer/GeneratorUtils.ts
+++ b/src/lib/components/renderer/GeneratorUtils.ts
@@ -26,11 +26,11 @@ export interface RenderContext {
  */
 export function findActiveEvent(timePrediction: any, percentStore: number) {
   if (!timePrediction?.timeline?.length) return null;
-  
+
   const totalDuration =
     timePrediction.timeline[timePrediction.timeline.length - 1]?.endTime || 0;
   const currentSeconds = (percentStore / 100) * totalDuration;
-  
+
   return (
     timePrediction.timeline.find(
       (e: any) => currentSeconds >= e.startTime && currentSeconds <= e.endTime,

--- a/src/lib/components/renderer/OnionLayerGenerator.ts
+++ b/src/lib/components/renderer/OnionLayerGenerator.ts
@@ -1,7 +1,4 @@
-import { 
-  type RenderContext, 
-  findActiveEvent 
-} from "./GeneratorUtils";
+import { type RenderContext, findActiveEvent } from "./GeneratorUtils";
 import type { Line, Point } from "../../../types";
 import { generateOnionLayers } from "../../../utils";
 

--- a/src/lib/components/renderer/PathGenerator.ts
+++ b/src/lib/components/renderer/PathGenerator.ts
@@ -4,10 +4,7 @@ import type { Line as PathLine } from "two.js/src/shapes/line";
 import type { Line, Point } from "../../../types";
 import { getCurvePoint } from "../../../utils/math";
 import { LINE_WIDTH } from "../../../config";
-import { 
-  type RenderContext, 
-  createPathAnchors 
-} from "./GeneratorUtils";
+import { type RenderContext, createPathAnchors } from "./GeneratorUtils";
 
 export function generatePathElements(
   targetLines: Line[],

--- a/src/lib/components/renderer/PointGenerator.ts
+++ b/src/lib/components/renderer/PointGenerator.ts
@@ -1,8 +1,5 @@
 import Two from "two.js";
-import { 
-  type RenderContext, 
-  setupTextLabel 
-} from "./GeneratorUtils";
+import { type RenderContext, setupTextLabel } from "./GeneratorUtils";
 import type { Line, Point, Shape, SequenceItem } from "../../../types";
 import { POINT_RADIUS } from "../../../config";
 import { calculateGlobalChainMeta } from "../../../utils/timeCalculator";
@@ -57,7 +54,11 @@ export function generatePointElements(
           x(point.x),
           y(point.y) - uiLength(0.15),
         );
-        setupTextLabel(pointText, `point-${idx + 1}-${idx1}-text`, uiLength(1.55));
+        setupTextLabel(
+          pointText,
+          `point-${idx + 1}-${idx1}-text`,
+          uiLength(1.55),
+        );
         pointGroup.add(pointElem, pointText);
         _points.push(pointGroup);
       } else {
@@ -118,7 +119,12 @@ export function generatePointElements(
         x(targetX || 72),
         y(targetY || 72) - uiLength(0.05),
       );
-      setupTextLabel(pointText, `targetpoint-${idx + 1}-text`, uiLength(1.4), 700);
+      setupTextLabel(
+        pointText,
+        `targetpoint-${idx + 1}-text`,
+        uiLength(1.4),
+        700,
+      );
       pointGroup.add(pointElem, pointText);
       _points.push(pointGroup);
     } else if (headingType === "piecewise") {
@@ -141,7 +147,12 @@ export function generatePointElements(
             x(seg.targetX || 72),
             y(seg.targetY || 72) - uiLength(0.05),
           );
-          setupTextLabel(pointText, `targetpoint-${idx + 1}-piecewise-${segIdx}-text`, uiLength(1.4), 700);
+          setupTextLabel(
+            pointText,
+            `targetpoint-${idx + 1}-piecewise-${segIdx}-text`,
+            uiLength(1.4),
+            700,
+          );
           pointGroup.add(pointElem, pointText);
           _points.push(pointGroup);
         }
@@ -166,7 +177,11 @@ export function generatePointElements(
         x(vertex.x),
         y(vertex.y) - uiLength(0.15),
       );
-      setupTextLabel(pointText, `obstacle-${shapeIdx}-${vertexIdx}-text`, uiLength(1.55));
+      setupTextLabel(
+        pointText,
+        `obstacle-${shapeIdx}-${vertexIdx}-text`,
+        uiLength(1.55),
+      );
       pointGroup.add(pointElem, pointText);
       _points.push(pointGroup);
     });

--- a/src/lib/components/renderer/PreviewPathGenerator.ts
+++ b/src/lib/components/renderer/PreviewPathGenerator.ts
@@ -2,10 +2,7 @@ import Two from "two.js";
 import type { Path } from "two.js/src/path";
 import type { Line as PathLine } from "two.js/src/shapes/line";
 import type { Line, Point } from "../../../types";
-import { 
-  type RenderContext, 
-  createPathAnchors 
-} from "./GeneratorUtils";
+import { type RenderContext, createPathAnchors } from "./GeneratorUtils";
 import { LINE_WIDTH } from "../../../config";
 
 export function generatePreviewPathElements(

--- a/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
@@ -7,7 +7,9 @@
   } from "../../../../config/defaults";
   import type { Settings, CustomFieldConfig } from "../../../../types/index";
   import { themesStore } from "../../../pluginsStore";
-  import { followRobotStore } from "../../../projectStore";  import { fieldZoom, fieldPan } from "../../../../stores";  import * as ICONS from "../../icons";
+  import { followRobotStore } from "../../../projectStore";
+  import { fieldZoom, fieldPan } from "../../../../stores";
+  import * as ICONS from "../../icons";
   import CustomFieldWizard from "../../settings/CustomFieldWizard.svelte";
 
   interface Props {

--- a/src/lib/components/shortcuts/clipboard.ts
+++ b/src/lib/components/shortcuts/clipboard.ts
@@ -10,10 +10,10 @@ import { selectedLineId, selectedPointId, notification } from "../../../stores";
 import { actionRegistry } from "../../actionRegistry";
 import type { Line, SequenceItem } from "../../../types/index";
 import { isUIElementFocused, getSelectedSequenceIndex } from "./utils";
-import { 
-  parseSelectionId, 
-  findSequenceItem, 
-  findSequenceItemIndex 
+import {
+  parseSelectionId,
+  findSequenceItem,
+  findSequenceItemIndex,
 } from "./itemUtils";
 
 // Internal clipboard state for shortcuts
@@ -55,17 +55,20 @@ export const generateName = (baseName: string, existingNames: string[]) => {
 
 function duplicateSequenceItem(
   item: any,
-  kind: 'wait' | 'rotate',
+  kind: "wait" | "rotate",
   sequence: SequenceItem[],
-  recordChange: (action?: string) => void
+  recordChange: (action?: string) => void,
 ) {
   const newItem = JSON.parse(JSON.stringify(item));
   newItem.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
   const existingNames = sequence
-    .filter((s) => actionRegistry.get(s.kind)?.[kind === 'wait' ? 'isWait' : 'isRotate'])
+    .filter(
+      (s) =>
+        actionRegistry.get(s.kind)?.[kind === "wait" ? "isWait" : "isRotate"],
+    )
     .map((s) => (s as any).name || "");
-  
+
   if (item.name && item.name.trim() !== "") {
     newItem.name = generateName(item.name, existingNames);
   } else {
@@ -283,9 +286,12 @@ export function paste(recordChange: (action?: string) => void) {
     newItem.id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
     const existingNames = sequence
-      .filter((s) => actionRegistry.get(s.kind)?.[kind === 'wait' ? 'isWait' : 'isRotate'])
+      .filter(
+        (s) =>
+          actionRegistry.get(s.kind)?.[kind === "wait" ? "isWait" : "isRotate"],
+      )
       .map((s) => (s as any).name || "");
-    
+
     if (newItem.name && newItem.name.trim() !== "") {
       newItem.name = generateName(newItem.name, existingNames);
     } else {

--- a/src/lib/components/shortcuts/itemUtils.ts
+++ b/src/lib/components/shortcuts/itemUtils.ts
@@ -2,7 +2,7 @@
 import { actionRegistry } from "../../actionRegistry";
 import type { SequenceItem, Line } from "../../../types/index";
 
-export type SelectionInfo = 
+export type SelectionInfo =
   | { type: "wait"; id: string }
   | { type: "rotate"; id: string }
   | { type: "point"; lineNum: number; ptIdx: number }
@@ -23,10 +23,10 @@ export function parseSelectionId(sel: string): SelectionInfo {
   }
   if (sel.startsWith("point-")) {
     const parts = sel.split("-");
-    return { 
-      type: "point", 
-      lineNum: Number(parts[1]), 
-      ptIdx: Number(parts[2]) 
+    return {
+      type: "point",
+      lineNum: Number(parts[1]),
+      ptIdx: Number(parts[2]),
     };
   }
   if (sel.startsWith("event-wait-")) {
@@ -34,7 +34,7 @@ export function parseSelectionId(sel: string): SelectionInfo {
     return {
       type: "event-wait",
       evIdx: Number(parts.pop()),
-      id: parts.slice(2).join("-")
+      id: parts.slice(2).join("-"),
     };
   }
   if (sel.startsWith("event-rotate-")) {
@@ -42,7 +42,7 @@ export function parseSelectionId(sel: string): SelectionInfo {
     return {
       type: "event-rotate",
       evIdx: Number(parts.pop()),
-      id: parts.slice(2).join("-")
+      id: parts.slice(2).join("-"),
     };
   }
   if (sel.startsWith("event-")) {
@@ -50,7 +50,7 @@ export function parseSelectionId(sel: string): SelectionInfo {
     return {
       type: "event-line",
       lineIdx: Number(parts[1]),
-      evIdx: Number(parts[2])
+      evIdx: Number(parts[2]),
     };
   }
   if (sel.startsWith("obstacle-")) {
@@ -58,21 +58,33 @@ export function parseSelectionId(sel: string): SelectionInfo {
     return {
       type: "obstacle",
       shapeIdx: Number(parts[1]),
-      vertexIdx: Number(parts[2])
+      vertexIdx: Number(parts[2]),
     };
   }
   return { type: "unknown", raw: sel };
 }
 
-export function findSequenceItem(sequence: SequenceItem[], id: string, kind: 'wait' | 'rotate'): any {
+export function findSequenceItem(
+  sequence: SequenceItem[],
+  id: string,
+  kind: "wait" | "rotate",
+): any {
   return sequence.find(
-    (s) => actionRegistry.get(s.kind)?.[kind === 'wait' ? 'isWait' : 'isRotate'] && (s as any).id === id
+    (s) =>
+      actionRegistry.get(s.kind)?.[kind === "wait" ? "isWait" : "isRotate"] &&
+      (s as any).id === id,
   );
 }
 
-export function findSequenceItemIndex(sequence: SequenceItem[], id: string, kind: 'wait' | 'rotate'): number {
+export function findSequenceItemIndex(
+  sequence: SequenceItem[],
+  id: string,
+  kind: "wait" | "rotate",
+): number {
   return sequence.findIndex(
-    (s) => actionRegistry.get(s.kind)?.[kind === 'wait' ? 'isWait' : 'isRotate'] && (s as any).id === id
+    (s) =>
+      actionRegistry.get(s.kind)?.[kind === "wait" ? "isWait" : "isRotate"] &&
+      (s as any).id === id,
   );
 }
 

--- a/src/lib/components/shortcuts/properties.ts
+++ b/src/lib/components/shortcuts/properties.ts
@@ -67,9 +67,7 @@ export function modifyValue(
     if (itemIdx !== -1) {
       const item = sequence[itemIdx] as any;
       if (
-        item &&
-        item.eventMarkers &&
-        item.eventMarkers[info.evIdx] &&
+        item?.eventMarkers?.[info.evIdx] &&
         !item.locked
       ) {
         const newPos = updateEventMarkerPosition(
@@ -91,9 +89,7 @@ export function modifyValue(
   if (info.type === "event-line") {
     const line = lines[info.lineIdx];
     if (
-      line &&
-      line.eventMarkers &&
-      line.eventMarkers[info.evIdx] &&
+      line?.eventMarkers?.[info.evIdx] &&
       !line.locked
     ) {
       const newPos = updateEventMarkerPosition(
@@ -114,9 +110,8 @@ export function modifyValue(
     if (lineIdx !== -1) {
       const line = lines[lineIdx];
       if (
-        line &&
-        line.eventMarkers &&
-        line.eventMarkers.length > 0 &&
+        line?.eventMarkers &&
+        line.eventMarkers?.length > 0 &&
         !line.locked
       ) {
         const lastIdx = line.eventMarkers.length - 1;

--- a/src/lib/components/shortcuts/properties.ts
+++ b/src/lib/components/shortcuts/properties.ts
@@ -9,11 +9,11 @@ import {
 } from "../../../utils/pointLinking";
 import type { Point } from "../../../types/index";
 import { isUIElementFocused } from "./utils";
-import { 
-  parseSelectionId, 
-  findSequenceItem, 
-  findSequenceItemIndex, 
-  updateEventMarkerPosition 
+import {
+  parseSelectionId,
+  findSequenceItem,
+  findSequenceItemIndex,
+  updateEventMarkerPosition,
 } from "./itemUtils";
 
 export function modifyValue(
@@ -66,10 +66,21 @@ export function modifyValue(
     const itemIdx = findSequenceItemIndex(sequence, info.id, kind);
     if (itemIdx !== -1) {
       const item = sequence[itemIdx] as any;
-      if (item && item.eventMarkers && item.eventMarkers[info.evIdx] && !item.locked) {
-        const newPos = updateEventMarkerPosition(item.eventMarkers[info.evIdx], 0.01 * delta);
+      if (
+        item &&
+        item.eventMarkers &&
+        item.eventMarkers[info.evIdx] &&
+        !item.locked
+      ) {
+        const newPos = updateEventMarkerPosition(
+          item.eventMarkers[info.evIdx],
+          0.01 * delta,
+        );
         const newMarkers = [...item.eventMarkers];
-        newMarkers[info.evIdx] = { ...newMarkers[info.evIdx], position: newPos };
+        newMarkers[info.evIdx] = {
+          ...newMarkers[info.evIdx],
+          position: newPos,
+        };
         sequence[itemIdx] = { ...item, eventMarkers: newMarkers };
         sequenceStore.set([...sequence]);
         recordChange("Move Event Marker");
@@ -79,8 +90,16 @@ export function modifyValue(
   }
   if (info.type === "event-line") {
     const line = lines[info.lineIdx];
-    if (line && line.eventMarkers && line.eventMarkers[info.evIdx] && !line.locked) {
-      const newPos = updateEventMarkerPosition(line.eventMarkers[info.evIdx], 0.01 * delta);
+    if (
+      line &&
+      line.eventMarkers &&
+      line.eventMarkers[info.evIdx] &&
+      !line.locked
+    ) {
+      const newPos = updateEventMarkerPosition(
+        line.eventMarkers[info.evIdx],
+        0.01 * delta,
+      );
       const newMarkers = [...line.eventMarkers];
       newMarkers[info.evIdx] = { ...newMarkers[info.evIdx], position: newPos };
       lines[info.lineIdx] = { ...line, eventMarkers: newMarkers };
@@ -94,9 +113,17 @@ export function modifyValue(
     const lineIdx = lines.findIndex((l) => l.id === get(selectedLineId));
     if (lineIdx !== -1) {
       const line = lines[lineIdx];
-      if (line && line.eventMarkers && line.eventMarkers.length > 0 && !line.locked) {
+      if (
+        line &&
+        line.eventMarkers &&
+        line.eventMarkers.length > 0 &&
+        !line.locked
+      ) {
         const lastIdx = line.eventMarkers.length - 1;
-        const newPos = updateEventMarkerPosition(line.eventMarkers[lastIdx], 0.01 * delta);
+        const newPos = updateEventMarkerPosition(
+          line.eventMarkers[lastIdx],
+          0.01 * delta,
+        );
         const newMarkers = [...line.eventMarkers];
         newMarkers[lastIdx] = { ...newMarkers[lastIdx], position: newPos };
         lines[lineIdx] = { ...line, eventMarkers: newMarkers };
@@ -266,7 +293,12 @@ export function toggleLock(recordChange: (action?: string) => void) {
     const kind = info.type === "wait" ? "wait" : "rotate";
     sequenceStore.update((seq) =>
       seq.map((s) => {
-        if (actionRegistry.get(s.kind)?.[kind === 'wait' ? 'isWait' : 'isRotate'] && (s as any).id === info.id) {
+        if (
+          actionRegistry.get(s.kind)?.[
+            kind === "wait" ? "isWait" : "isRotate"
+          ] &&
+          (s as any).id === info.id
+        ) {
           return { ...s, locked: !(s as any).locked };
         }
         return s;

--- a/src/lib/components/shortcuts/selection.ts
+++ b/src/lib/components/shortcuts/selection.ts
@@ -160,9 +160,7 @@ export function removeSelected(recordChange: (action?: string) => void) {
     if (itemType === "wait" || itemType === "rotate") {
       const item = findSequenceItem(sequence, itemId, itemType);
       if (
-        item &&
-        item.eventMarkers &&
-        item.eventMarkers[evIdx] &&
+        item?.eventMarkers?.[evIdx] &&
         !item.locked
       ) {
         const itemIdx = findSequenceItemIndex(sequence, itemId, itemType);

--- a/src/lib/components/shortcuts/selection.ts
+++ b/src/lib/components/shortcuts/selection.ts
@@ -17,11 +17,11 @@ import { actionRegistry } from "../../actionRegistry";
 import { updateLinkedWaypoints } from "../../../utils/pointLinking";
 import { FIELD_SIZE } from "../../../config";
 import { isUIElementFocused, getSelectedSequenceIndex } from "./utils";
-import { 
-  parseSelectionId, 
-  findSequenceItem, 
-  findSequenceItemIndex, 
-  updateEventMarkerPosition 
+import {
+  parseSelectionId,
+  findSequenceItem,
+  findSequenceItemIndex,
+  updateEventMarkerPosition,
 } from "./itemUtils";
 
 export function removeSelected(recordChange: (action?: string) => void) {
@@ -60,13 +60,13 @@ export function removeSelected(recordChange: (action?: string) => void) {
       eventMarkersToDelete.push({
         itemType: info.type === "event-wait" ? "wait" : "rotate",
         evIdx: info.evIdx,
-        itemId: info.id
+        itemId: info.id,
       });
     } else if (info.type === "event-line") {
       eventMarkersToDelete.push({
         itemType: "line",
         evIdx: info.evIdx,
-        itemId: String(info.lineIdx)
+        itemId: String(info.lineIdx),
       });
     }
   });
@@ -159,12 +159,19 @@ export function removeSelected(recordChange: (action?: string) => void) {
   eventMarkersToDelete.forEach(({ itemType, itemId, evIdx }) => {
     if (itemType === "wait" || itemType === "rotate") {
       const item = findSequenceItem(sequence, itemId, itemType);
-      if (item && item.eventMarkers && item.eventMarkers[evIdx] && !item.locked) {
+      if (
+        item &&
+        item.eventMarkers &&
+        item.eventMarkers[evIdx] &&
+        !item.locked
+      ) {
         const itemIdx = findSequenceItemIndex(sequence, itemId, itemType);
         if (itemIdx !== -1) {
           sequence[itemIdx] = {
             ...item,
-            eventMarkers: item.eventMarkers.filter((_: any, i: number) => i !== evIdx),
+            eventMarkers: item.eventMarkers.filter(
+              (_: any, i: number) => i !== evIdx,
+            ),
           };
           sequenceChanged = true;
         }
@@ -172,10 +179,17 @@ export function removeSelected(recordChange: (action?: string) => void) {
     } else if (itemType === "line") {
       const lineIdx = Number(itemId);
       const line = lines[lineIdx];
-      if (line && line.eventMarkers && line.eventMarkers[evIdx] && !line.locked) {
+      if (
+        line &&
+        line.eventMarkers &&
+        line.eventMarkers[evIdx] &&
+        !line.locked
+      ) {
         lines[lineIdx] = {
           ...line,
-          eventMarkers: line.eventMarkers.filter((_: any, i: number) => i !== evIdx),
+          eventMarkers: line.eventMarkers.filter(
+            (_: any, i: number) => i !== evIdx,
+          ),
         };
         linesChanged = true;
       }
@@ -341,9 +355,15 @@ export function movePoint(
       if (itemIdx !== -1) {
         const item = sequence[itemIdx] as any;
         if (item && item.eventMarkers && item.eventMarkers[info.evIdx]) {
-          const newPos = updateEventMarkerPosition(item.eventMarkers[info.evIdx], 0.01 * (dx + dy));
+          const newPos = updateEventMarkerPosition(
+            item.eventMarkers[info.evIdx],
+            0.01 * (dx + dy),
+          );
           const newMarkers = [...item.eventMarkers];
-          newMarkers[info.evIdx] = { ...newMarkers[info.evIdx], position: newPos };
+          newMarkers[info.evIdx] = {
+            ...newMarkers[info.evIdx],
+            position: newPos,
+          };
           sequence[itemIdx] = { ...item, eventMarkers: newMarkers };
           sequenceChanged = true;
         }
@@ -351,9 +371,15 @@ export function movePoint(
     } else if (info.type === "event-line") {
       const line = lines[info.lineIdx];
       if (line && line.eventMarkers && line.eventMarkers[info.evIdx]) {
-        const newPos = updateEventMarkerPosition(line.eventMarkers[info.evIdx], 0.01 * (dx + dy));
+        const newPos = updateEventMarkerPosition(
+          line.eventMarkers[info.evIdx],
+          0.01 * (dx + dy),
+        );
         const newMarkers = [...line.eventMarkers];
-        newMarkers[info.evIdx] = { ...newMarkers[info.evIdx], position: newPos };
+        newMarkers[info.evIdx] = {
+          ...newMarkers[info.evIdx],
+          position: newPos,
+        };
         lines[info.lineIdx] = { ...line, eventMarkers: newMarkers };
         linesChanged = true;
       }

--- a/src/tests/lib/components/shortcuts/elements.test.ts
+++ b/src/tests/lib/components/shortcuts/elements.test.ts
@@ -43,7 +43,7 @@ describe("elements", () => {
   const testSequenceAddition = (
     addFn: (cb: any) => void,
     actionName: string,
-    kind: string
+    kind: string,
   ) => {
     const cb = vi.fn();
     addFn(cb);

--- a/src/tests/utils/drivetrain/swerve.test.ts
+++ b/src/tests/utils/drivetrain/swerve.test.ts
@@ -16,7 +16,13 @@ describe("calculateSwerveDriveAngles", () => {
     });
   });
 
-  const expectAngles = (angles: any, fl: number, bl: number, fr: number, br: number) => {
+  const expectAngles = (
+    angles: any,
+    fl: number,
+    bl: number,
+    fr: number,
+    br: number,
+  ) => {
     expect(angles.frontLeft).toBeCloseTo(fl);
     expect(angles.backLeft).toBeCloseTo(bl);
     expect(angles.frontRight).toBeCloseTo(fr);

--- a/src/tests/utils/drivetrain/velocity.test.ts
+++ b/src/tests/utils/drivetrain/velocity.test.ts
@@ -65,7 +65,7 @@ describe("calculateDrivetrainSpeeds", () => {
 
   const mockRobotStates = (
     state1: { x: number; y: number; heading: number },
-    state2: { x: number; y: number; heading: number }
+    state2: { x: number; y: number; heading: number },
   ) => {
     vi.mocked(animation.calculateRobotState).mockReset();
     vi.mocked(animation.calculateRobotState)

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -208,6 +208,70 @@ function getHeadingBase(
   return 0;
 }
 
+function evaluatePiecewiseSegment(
+  seg: any,
+  t: number,
+  line: Line,
+  previousPoint: Point,
+  isStart: boolean,
+): number {
+  if (seg.heading === "linear") {
+    const sDeg = seg.startDeg ?? 0;
+    const eDeg = seg.endDeg ?? 0;
+    let localT = 0;
+    if (seg.tEnd > seg.tStart) {
+      localT = (t - seg.tStart) / (seg.tEnd - seg.tStart);
+    }
+
+    const diff = eDeg - sDeg;
+    const normalized = ((diff % 360) + 360) % 360;
+    const shortest = normalized > 180 ? normalized - 360 : normalized;
+    const longest = shortest > 0 ? shortest - 360 : shortest + 360;
+
+    return transformAngle(sDeg + (seg.reverse ? longest : shortest) * localT);
+  }
+
+  if (seg.heading === "constant")
+    return transformAngle((seg.degrees ?? 0) + (seg.reverse ? 180 : 0));
+
+  let ref1: Point2D = previousPoint;
+  let ref2: Point2D = line.endPoint;
+
+  if (isStart) {
+    if (seg.heading === "tangential" && line.controlPoints?.length > 0) {
+      ref2 =
+        getFirstValidControlPoint(line.controlPoints, previousPoint) || ref2;
+    } else if (seg.heading === "facingPoint") {
+      const tx = seg.targetX || 0;
+      const ty = seg.targetY || 0;
+      // Piecewise start always uses t=0 for geometry lookup
+      const pos = previousPoint;
+      let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
+      if (seg.reverse) angle += 180;
+      return transformAngle(angle);
+    }
+    return getHeadingBase(seg, previousPoint, ref2);
+  } else {
+    if (seg.heading === "tangential" && line.controlPoints?.length > 0) {
+      ref1 =
+        getFirstValidControlPoint(line.controlPoints, line.endPoint, true) ||
+        ref1;
+    } else if (seg.heading === "facingPoint") {
+      const tx = seg.targetX || 0;
+      const ty = seg.targetY || 0;
+      const pos = line.endPoint;
+      let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
+      if (seg.reverse) angle += 180;
+      return transformAngle(angle);
+    }
+    return getHeadingBase(
+      seg,
+      seg.heading === "facingPoint" ? line.endPoint : ref1,
+      line.endPoint,
+    );
+  }
+}
+
 export function getLineStartHeading(
   line: Line | undefined,
   previousPoint: Point,
@@ -218,8 +282,7 @@ export function getLineStartHeading(
   if (!line || !line.endPoint) return 0;
 
   const isGlobal =
-    globalOverride?.globalHeading &&
-    globalOverride.globalHeading !== "none";
+    globalOverride?.globalHeading && globalOverride.globalHeading !== "none";
 
   const effectiveSource = isGlobal
     ? {
@@ -254,45 +317,7 @@ export function getLineStartHeading(
     if (!activeSeg && segments.length > 0) activeSeg = segments[0];
 
     if (activeSeg) {
-      if (activeSeg.heading === "linear") {
-        const sDeg = activeSeg.startDeg ?? 0;
-        const eDeg = activeSeg.endDeg ?? 0;
-        let localT = 0;
-        if (activeSeg.tEnd > activeSeg.tStart) {
-          localT = (t - activeSeg.tStart) / (activeSeg.tEnd - activeSeg.tStart);
-        }
-
-        const diff = eDeg - sDeg;
-        const normalized = ((diff % 360) + 360) % 360;
-        const shortest = normalized > 180 ? normalized - 360 : normalized;
-        const longest = shortest > 0 ? shortest - 360 : shortest + 360;
-
-        return transformAngle(
-          sDeg + (activeSeg.reverse ? longest : shortest) * localT,
-        );
-      }
-      if (activeSeg.heading === "constant")
-        return transformAngle(
-          (activeSeg.degrees ?? 0) + (activeSeg.reverse ? 180 : 0),
-        );
-
-      let nextP: Point2D = line.endPoint;
-      if (
-        activeSeg.heading === "tangential" &&
-        line.controlPoints?.length > 0
-      ) {
-        nextP =
-          getFirstValidControlPoint(line.controlPoints, previousPoint) || nextP;
-      } else if (activeSeg.heading === "facingPoint") {
-        const tx = activeSeg.targetX || 0;
-        const ty = activeSeg.targetY || 0;
-        // Piecewise start always uses t=0 for geometry lookup
-        const pos = previousPoint;
-        let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
-        if (activeSeg.reverse) angle += 180;
-        return transformAngle(angle);
-      }
-      return getHeadingBase(activeSeg as any, previousPoint, nextP);
+      return evaluatePiecewiseSegment(activeSeg, t, line, previousPoint, true);
     }
     return 0;
   }
@@ -327,8 +352,7 @@ export function getLineEndHeading(
   if (!line || !line.endPoint) return 0;
 
   const isGlobal =
-    globalOverride?.globalHeading &&
-    globalOverride.globalHeading !== "none";
+    globalOverride?.globalHeading && globalOverride.globalHeading !== "none";
 
   const effectiveSource = isGlobal
     ? {
@@ -364,46 +388,7 @@ export function getLineEndHeading(
       lastSeg = segments[segments.length - 1];
 
     if (lastSeg) {
-      if (lastSeg.heading === "linear") {
-        const sDeg = lastSeg.startDeg ?? 0;
-        const eDeg = lastSeg.endDeg ?? 0;
-        let localT = 0;
-        if (lastSeg.tEnd > lastSeg.tStart) {
-          localT = (t - lastSeg.tStart) / (lastSeg.tEnd - lastSeg.tStart);
-        }
-
-        const diff = eDeg - sDeg;
-        const normalized = ((diff % 360) + 360) % 360;
-        const shortest = normalized > 180 ? normalized - 360 : normalized;
-        const longest = shortest > 0 ? shortest - 360 : shortest + 360;
-
-        return transformAngle(
-          sDeg + (lastSeg.reverse ? longest : shortest) * localT,
-        );
-      }
-      if (lastSeg.heading === "constant")
-        return transformAngle(
-          (lastSeg.degrees ?? 0) + (lastSeg.reverse ? 180 : 0),
-        );
-
-      let prevP: Point2D = previousPoint;
-      if (lastSeg.heading === "tangential" && line.controlPoints?.length > 0) {
-        prevP =
-          getFirstValidControlPoint(line.controlPoints, line.endPoint, true) ||
-          prevP;
-      } else if (lastSeg.heading === "facingPoint") {
-        const tx = lastSeg.targetX || 0;
-        const ty = lastSeg.targetY || 0;
-        const pos = line.endPoint;
-        let angle = Math.atan2(ty - pos.y, tx - pos.x) * (180 / Math.PI);
-        if (lastSeg.reverse) angle += 180;
-        return transformAngle(angle);
-      }
-      return getHeadingBase(
-        lastSeg as any,
-        lastSeg.heading === "facingPoint" ? line.endPoint : prevP,
-        line.endPoint,
-      );
+      return evaluatePiecewiseSegment(lastSeg, t, line, previousPoint, false);
     }
     return 0;
   }

--- a/src/utils/timeCalculator.ts
+++ b/src/utils/timeCalculator.ts
@@ -1470,10 +1470,9 @@ export function calculatePathTime(
     });
   };
 
-  const initialSeq =
-    sequence?.length
-      ? sequence
-      : lines.map((ln) => ({ kind: "path", lineId: ln.id! }) as SequenceItem);
+  const initialSeq = sequence?.length
+    ? sequence
+    : lines.map((ln) => ({ kind: "path", lineId: ln.id! }) as SequenceItem);
 
   processSequence(initialSeq, lines);
 


### PR DESCRIPTION
This pull request implements the cleanup workflow to eliminate dead code and improve maintainability through DRY refactoring.

Changes made:
- Identified a significant duplication of piecewise segment evaluation logic in `getLineStartHeading` and `getLineEndHeading` within `src/utils/math.ts`. Extracted this duplicated logic into a shared helper function `evaluatePiecewiseSegment`.
- Executed linting to fix various syntax-level formatting inconsistencies.
- Verified that all changes are safe by running the entire test suite and ensuring no regressions are present.

---
*PR created automatically by Jules for task [936967818760609603](https://jules.google.com/task/936967818760609603) started by @Mallen220*