### PR TITLE
Refactor App.svelte and Navbar.svelte to Svelte 5

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-
-
   import { onMount, onDestroy } from "svelte";
   import { get } from "svelte/store";
   import * as d3 from "d3";
@@ -1388,7 +1386,9 @@
         )
       : null,
   );
-  let currentTotalTime = $derived(timePrediction.totalTime / 1000);
+  let currentTotalTime = $derived(
+    timePrediction?.totalTime ? timePrediction.totalTime / 1000 : 0,
+  );
   let committedTotalTime = $derived(
     committedTimePrediction ? committedTimePrediction.totalTime / 1000 : 0,
   );

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import { onMount, onDestroy } from "svelte";
   import { get } from "svelte/store";
@@ -1239,7 +1239,7 @@
 
   let settings = $derived($settingsStore);
   // Manage Time-based Autosave
-  run(() => {
+  $effect(() => {
     if (autosaveIntervalId) {
       clearInterval(autosaveIntervalId);
       autosaveIntervalId = null;
@@ -1253,7 +1253,7 @@
   let effectiveShowSidebar = $derived(
     $isPresentationMode ? false : showSidebar,
   );
-  run(() => {
+  $effect(() => {
     if (controlTabContainer && _controlTabObserver) {
       try {
         _controlTabObserver.observe(controlTabContainer);
@@ -1261,7 +1261,7 @@
       } catch (e) {}
     }
   });
-  run(() => {
+  $effect(() => {
     if (!effectiveShowSidebar && statsOpen) statsOpen = false;
   });
   let isLargeScreen = $derived(innerWidth >= 1024);
@@ -1276,7 +1276,7 @@
   let playbackSpeed = $derived($playbackSpeedStore);
   let loopRange = $derived($loopRangeStore);
   let loopRangeActive = $derived($loopRangeActiveStore);
-  run(() => {
+  $effect(() => {
     if (
       userFieldHeightLimit === null &&
       mainContentHeight > 0 &&
@@ -1285,7 +1285,7 @@
       userFieldHeightLimit = mainContentHeight * 0.6;
     }
   });
-  run(() => {
+  $effect(() => {
     if (userFieldLimit === null && mainContentWidth > 0 && isLargeScreen) {
       userFieldLimit = mainContentWidth * 0.49;
     }
@@ -1331,7 +1331,7 @@
   let canUndo = $derived($canUndoStore);
   let canRedo = $derived($canRedoStore);
   // --- Animation Logic ---
-  run(() => {
+  $effect(() => {
     if (!$isDraggingStore) {
       timePrediction = calculatePathTime(
         startPoint,
@@ -1343,7 +1343,7 @@
     }
   });
   // Continuous validation when path/settings change
-  run(() => {
+  $effect(() => {
     // depend on timePrediction to ensure validation with the latest timeline
     if (
       $startPointStore &&
@@ -1371,7 +1371,7 @@
       collisionMarkers.set([]);
     }
   });
-  run(() => {
+  $effect(() => {
     if (settings) debouncedSaveSettings(settings);
   });
   // Diff Mode Animation Logic
@@ -1401,7 +1401,7 @@
   let animationDuration = $derived(
     getAnimationDuration(effectiveDuration, playbackSpeed),
   );
-  run(() => {
+  $effect(() => {
     if (animationController) {
       animationController.setDuration(animationDuration);
       animationController.setLoop(loopAnimation);
@@ -1415,7 +1415,7 @@
     }
   });
   // Sync playing store -> controller
-  run(() => {
+  $effect(() => {
     if (animationController) {
       if (playing && animationController.isPlaying() === false)
         animationController.play();
@@ -1423,7 +1423,7 @@
         animationController.pause();
     }
   });
-  run(() => {
+  $effect(() => {
     if (timePrediction?.timeline && (lines.length > 0 || sequence.length > 0)) {
       // Calculate Global Time based on effective duration
       const globalTime = (percent / 100) * effectiveDuration;
@@ -1483,7 +1483,7 @@
       committedRobotState = null;
     }
   });
-  run(() => {
+  $effect(() => {
     if (isLargeScreen) {
       // Ensure visible on large screens
       controlTabHidden = false;
@@ -1529,7 +1529,7 @@
       }
     })(),
   );
-  run(() => {
+  $effect(() => {
     if ($exportDialogState.isOpen && exportDialog) {
       exportDialog.openWithFormat(
         $exportDialogState.format,
@@ -1540,7 +1540,7 @@
     }
   });
   // --- Apply Theme ---
-  run(() => {
+  $effect(() => {
     // Depend on themesStore so re-run when plugins load
     const registeredThemes = $themesStore;
     if (settings) {
@@ -1617,7 +1617,7 @@
     }
   });
   // --- Apply Program Font Size ---
-  run(() => {
+  $effect(() => {
     if (settings?.programFontSize) {
       document.documentElement.style.fontSize = `${settings.programFontSize}%`;
     } else {

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import type { Point, Line, Settings, SequenceItem } from "../types";
   import { onMount, onDestroy } from "svelte";
@@ -97,7 +97,7 @@
     exportDialogState.set({ isOpen: true, format, exporterName });
   }
 
-  run(() => {
+  $effect(() => {
     if (settings) {
       settings.rWidth = robotWidth;
       settings.rLength = robotLength;

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,7 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-
-
   import type { Point, Line, Settings, SequenceItem } from "../types";
   import { onMount, onDestroy } from "svelte";
   import {
@@ -98,9 +96,15 @@
   }
 
   $effect(() => {
-    if (settings) {
-      settings.rWidth = robotWidth;
-      settings.rLength = robotLength;
+    if (
+      settings &&
+      (settings.rWidth !== robotWidth || settings.rLength !== robotLength)
+    ) {
+      settings = {
+        ...settings,
+        rWidth: robotWidth,
+        rLength: robotLength,
+      };
     }
   });
 
@@ -340,7 +344,7 @@
           >Est. Time</span
         >
         <span class="font-semibold text-neutral-800 dark:text-neutral-200"
-          >{formatEstimatedTime(timePrediction.totalTime)}</span
+          >{formatEstimatedTime(timePrediction?.totalTime ?? 0)}</span
         >
       </div>
       <div


### PR DESCRIPTION
Migrated legacy `run()` invocations to `$effect()` in `App.svelte` and `Navbar.svelte` as requested. Evaluated and removed usage of `svelte/legacy` to fully embrace Svelte 5 patterns. Validated that all reactivity and DOM bindings continue to correctly function via the component tests and build scripts.

---
*PR created automatically by Jules for task [5784988836632807152](https://jules.google.com/task/5784988836632807152) started by @Mallen220*