### PR TITLE
chore: remove dead code polygonCenter

### DIFF
--- a/src/tests/geometry.test.ts
+++ b/src/tests/geometry.test.ts
@@ -5,7 +5,6 @@ import {
   pointInPolygon,
   minDistanceToPolygon,
   pointToLineDistance,
-  polygonCenter,
   getRobotCorners,
   convexHull,
 } from "../utils/geometry";
@@ -91,14 +90,6 @@ describe("Geometry Utils", () => {
 
       // Point inside (5,5) -> distance to closest edge
       expect(minDistanceToPolygon([5, 5], square)).toBe(5);
-    });
-  });
-
-  describe("polygonCenter", () => {
-    it("calculates centroid of polygon", () => {
-      const center = polygonCenter(square);
-      expect(center[0]).toBe(5);
-      expect(center[1]).toBe(5);
     });
   });
 

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -86,20 +86,6 @@ export function pointToLineDistance(
 }
 
 /**
- * Calculate the center (centroid) of a polygon
- */
-export function polygonCenter(vertices: BasePoint[]): number[] {
-  const sum = vertices.reduce(
-    (acc, vertex) => {
-      return [acc[0] + vertex.x, acc[1] + vertex.y];
-    },
-    [0, 0],
-  );
-
-  return [sum[0] / vertices.length, sum[1] / vertices.length];
-}
-
-/**
  * Calculate the four corner points of a robot at a given position and heading
  * Assumes the robot is a rectangle centered at (x, y) with the given heading angle
  * The heading convention: 0° = right, 90° = down, 180° = left, 270° = up


### PR DESCRIPTION
Cleanup of dead code (`polygonCenter`) from `src/utils/geometry.ts` and its associated tests.

---
*PR created automatically by Jules for task [4512891913024399641](https://jules.google.com/task/4512891913024399641) started by @Mallen220*