### PR TITLE
Fix z-index for save and unsaved changes dialogs

### DIFF
--- a/src/lib/components/dialogs/SaveNameDialog.svelte
+++ b/src/lib/components/dialogs/SaveNameDialog.svelte
@@ -72,7 +72,7 @@
 
 {#if show}
   <div
-    class="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+    class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-sm"
     role="dialog"
     aria-modal="true"
   >

--- a/src/lib/components/dialogs/UnsavedChangesDialog.svelte
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.svelte
@@ -23,7 +23,7 @@
 
 {#if show}
   <div
-    class="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm"
+    class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/50 backdrop-blur-sm"
     role="dialog"
     aria-modal="true"
   >


### PR DESCRIPTION
- Increased z-index of `SaveNameDialog` from `z-[60]` to `z-[9999]`.
- Increased z-index of `UnsavedChangesDialog` from `z-[60]` to `z-[9999]`.

---
*PR created automatically by Jules for task [13165096355080130959](https://jules.google.com/task/13165096355080130959) started by @Mallen220*