### PR TITLE
Migrate components to Svelte 5 logic

### DIFF
--- a/src/lib/components/common/SearchableDropdown.svelte
+++ b/src/lib/components/common/SearchableDropdown.svelte
@@ -1,7 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run, preventDefault } from "svelte/legacy";
-
   import { createEventDispatcher, tick } from "svelte";
   import { slide } from "svelte/transition";
 
@@ -36,7 +34,7 @@
   );
 
   // Reset highlight when options change
-  run(() => {
+  $effect(() => {
     if (filteredOptions) {
       highlightedIndex = -1;
     }
@@ -167,7 +165,10 @@
             {index === highlightedIndex
             ? 'bg-purple-100 dark:bg-purple-900/40 text-purple-900 dark:text-purple-100'
             : 'hover:bg-purple-50 dark:hover:bg-purple-900/20 text-neutral-700 dark:text-neutral-200'}"
-          onmousedown={preventDefault(() => selectOption(option))}
+          onmousedown={(e) => {
+            e.preventDefault();
+            selectOption(option);
+          }}
         >
           {option}
         </div>

--- a/src/lib/components/settings/CustomFieldWizard.svelte
+++ b/src/lib/components/settings/CustomFieldWizard.svelte
@@ -1,7 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run, stopPropagation } from "svelte/legacy";
-
   import { createEventDispatcher } from "svelte";
   import { fade, fly } from "svelte/transition";
   import { cubicInOut } from "svelte/easing";
@@ -34,7 +32,7 @@
   let imageContainer: HTMLDivElement | undefined = $state();
 
   let wasOpen = $state(false);
-  run(() => {
+  $effect(() => {
     if (isOpen && !wasOpen) {
       wasOpen = true;
       // Reset state on open


### PR DESCRIPTION
Migrates Svelte 4 legacy constructs to native Svelte 5 logic in CustomFieldWizard and SearchableDropdown.

---
*PR created automatically by Jules for task [2311381775149058726](https://jules.google.com/task/2311381775149058726) started by @Mallen220*