### PR TITLE
test: add tests to CustomFieldWizard and RobotProfileManager

### DIFF
--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -282,15 +282,15 @@
     increasePlaybackSpeed: () => changePlaybackSpeedBy(0.25, play),
     decreasePlaybackSpeed: () => changePlaybackSpeedBy(-0.25, play),
     resetPlaybackSpeed: () => resetPlaybackSpeed(),
-    toggleLoop: () => loopAnimationStore.update(v => !v),
+    toggleLoop: () => loopAnimationStore.update((v) => !v),
     toggleSectionLoop: () => {
       let currentActive = false;
-      loopRangeActiveStore.subscribe(v => currentActive = v)();
+      loopRangeActiveStore.subscribe((v) => (currentActive = v))();
       const newVal = !currentActive;
       loopRangeActiveStore.set(newVal);
       if (newVal) {
         let currentPercent = 0;
-        percentStore.subscribe(v => currentPercent = v)();
+        percentStore.subscribe((v) => (currentPercent = v))();
         loopRangeStore.set([Math.floor(currentPercent), 100]);
       }
     },

--- a/src/lib/components/dialogs/KeyboardShortcutsDialog.svelte
+++ b/src/lib/components/dialogs/KeyboardShortcutsDialog.svelte
@@ -250,10 +250,7 @@
         // If the binding wasn't present in user settings, add the default back
         settings = {
           ...settings,
-          keyBindings: [
-            ...(settings.keyBindings || []),
-            { ...defaultBinding },
-          ],
+          keyBindings: [...(settings.keyBindings || []), { ...defaultBinding }],
         };
       }
       return;

--- a/src/lib/components/dialogs/SettingsDialog.svelte
+++ b/src/lib/components/dialogs/SettingsDialog.svelte
@@ -270,7 +270,11 @@
         handleSave();
       }
     }}
-    onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { if (e.target === e.currentTarget) handleSave(); } }}
+    onkeydown={(e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        if (e.target === e.currentTarget) handleSave();
+      }
+    }}
     tabindex="-1"
     transition:fade={{ duration: 300, easing: cubicInOut }}
     class="bg-black bg-opacity-40 flex flex-col justify-center items-center fixed top-0 left-0 w-full h-full z-[1005] backdrop-blur-sm"

--- a/src/lib/components/settings/CustomFieldWizard.test.ts
+++ b/src/lib/components/settings/CustomFieldWizard.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import CustomFieldWizardWrapper from './CustomFieldWizardWrapper.svelte';
+import CustomFieldWizard from './CustomFieldWizard.svelte';
+
+describe('CustomFieldWizard', () => {
+    let originalFileReader: any;
+    let originalAlert: any;
+
+    beforeEach(() => {
+        originalFileReader = window.FileReader;
+        originalAlert = window.alert;
+        window.alert = vi.fn();
+
+        // Mock pointer capture methods for jsdom
+        if (!Element.prototype.setPointerCapture) {
+            Element.prototype.setPointerCapture = vi.fn();
+        }
+        if (!Element.prototype.releasePointerCapture) {
+            Element.prototype.releasePointerCapture = vi.fn();
+        }
+        if (!Element.prototype.hasPointerCapture) {
+            Element.prototype.hasPointerCapture = vi.fn(() => true);
+        }
+    });
+
+    afterEach(() => {
+        window.FileReader = originalFileReader;
+        window.alert = originalAlert;
+        vi.restoreAllMocks();
+    });
+
+    it('renders and shows initial step 1', () => {
+        const { getByText } = render(CustomFieldWizard, { props: { isOpen: true } });
+        expect(getByText('Custom Field Map Wizard')).toBeDefined();
+        expect(getByText('Upload a custom field map image')).toBeDefined();
+        expect(getByText('Select Image')).toBeDefined();
+    });
+
+    it('does not render when isOpen is false', () => {
+        const { queryByText } = render(CustomFieldWizard, { props: { isOpen: false } });
+        expect(queryByText('Custom Field Map Wizard')).toBeNull();
+    });
+
+    it('handles image upload success and goes to step 2', async () => {
+        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+
+        // Mock FileReader
+        window.FileReader = class FileReader {
+            onload: any;
+            readAsDataURL() {
+                this.result = "data:image/png;base64,dummy";
+                if (this.onload) this.onload();
+            }
+        } as any;
+
+        const input = container.querySelector('#wizard-image-input');
+        expect(input).not.toBeNull();
+
+        const file = new File(["dummy content"], "test.png", { type: "image/png" });
+        Object.defineProperty(input, 'files', {
+            value: [file]
+        });
+
+        await fireEvent.change(input!);
+
+        // Should move to step 2 automatically
+        await waitFor(() => {
+            // Check if step 2 handles are present
+            expect(container.querySelector('.cursor-ns-resize')).not.toBeNull();
+        });
+    });
+
+    it('handles image upload read failure', async () => {
+        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+
+        window.FileReader = class FileReader {
+            onload: any;
+            readAsDataURL() {
+                this.result = null; // not a string
+                if (this.onload) this.onload();
+            }
+        } as any;
+
+        const input = container.querySelector('#wizard-image-input');
+        const file = new File(["dummy content"], "test.png", { type: "image/png" });
+        Object.defineProperty(input, 'files', { value: [file] });
+
+        await fireEvent.change(input!);
+
+        expect(window.alert).toHaveBeenCalledWith("Failed to read image file. Please try again.");
+    });
+
+    it('handles image upload error', async () => {
+        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+
+        window.FileReader = class FileReader {
+            onerror: any;
+            error = { message: "Test error" };
+            readAsDataURL() {
+                if (this.onerror) this.onerror();
+            }
+        } as any;
+
+        const input = container.querySelector('#wizard-image-input');
+        const file = new File(["dummy content"], "test.png", { type: "image/png" });
+        Object.defineProperty(input, 'files', { value: [file] });
+
+        await fireEvent.change(input!);
+
+        expect(window.alert).toHaveBeenCalledWith("Error reading file: Test error");
+    });
+
+    it('can transition back and forth between steps using buttons', async () => {
+        const { getByText, container } = render(CustomFieldWizard, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
+
+        // Step 1 check button
+        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
+
+        // Step 2
+        await waitFor(() => {
+            expect(getByText("Next")).toBeDefined();
+        });
+
+        const img = container.querySelector('img');
+        if (img) {
+            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
+            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
+            await fireEvent.load(img);
+        }
+
+        // Click next -> Step 3
+        await fireEvent.click(getByText("Next"));
+        await waitFor(() => {
+            expect(getByText("Save & Apply")).toBeDefined();
+        });
+
+        // Click back -> Step 2
+        await fireEvent.click(getByText("Back"));
+        await waitFor(() => {
+             expect(getByText("Next")).toBeDefined();
+        });
+    });
+
+    it('handles pointer events for dragging bounding box', async () => {
+        const { container } = render(CustomFieldWizard, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
+
+        // Go to step 2
+        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
+        await waitFor(() => {
+            expect(container.querySelector('.cursor-move')).not.toBeNull();
+        });
+
+        const moveBox = container.querySelector('.cursor-move') as HTMLElement;
+
+        // Mock pointer events and getBoundingClientRect
+        const imageContainer = moveBox.parentElement;
+        if(imageContainer) {
+            imageContainer.getBoundingClientRect = () => ({ width: 1000, height: 1000, left: 0, top: 0, right: 1000, bottom: 1000, x: 0, y: 0, toJSON: () => {} } as DOMRect);
+        }
+
+        // Test pointer move
+        await fireEvent.pointerDown(moveBox, { clientX: 100, clientY: 100, pointerId: 1 });
+        await fireEvent.pointerMove(moveBox, { clientX: 200, clientY: 200 });
+        await fireEvent.pointerUp(moveBox, { pointerId: 1 });
+
+        // Box x/y should have changed (initially 0.1, 0.1, delta is 100/1000 = +0.1) -> 0.2
+        expect(moveBox.style.left).toBe('20%');
+        expect(moveBox.style.top).toBe('20%');
+
+        // Test pointer resize (W handle)
+        const wHandle = container.querySelector('.cursor-ew-resize') as HTMLElement; // Left handle
+        await fireEvent.pointerDown(wHandle, { clientX: 200, clientY: 200, pointerId: 2 });
+        // Move left by 100px (-0.1 relative)
+        await fireEvent.pointerMove(wHandle, { clientX: 100, clientY: 200 });
+        await fireEvent.pointerUp(wHandle, { pointerId: 2 });
+
+        // X should go back to 0.1, width should increase from 0.8 to 0.9
+        expect(moveBox.style.left).toBe('10%');
+        expect(moveBox.style.width).toBe('90%');
+    });
+
+    it('saves configuration and emits events', async () => {
+        const mockSave = vi.fn();
+        const mockClose = vi.fn();
+
+        const { getByText, container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 }, onsave: mockSave, onclose: mockClose } });
+
+        // Go to step 2
+        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
+        await waitFor(() => {
+            expect(getByText("Next")).toBeDefined();
+        });
+
+        // Mock image dimensions
+        const img = container.querySelector('img');
+        if (img) {
+            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
+            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
+            await fireEvent.load(img);
+        }
+
+        // Go to step 3
+        await fireEvent.click(getByText("Next"));
+        await waitFor(() => {
+            expect(getByText("Save & Apply")).toBeDefined();
+        });
+
+        // Click save
+        await fireEvent.click(getByText("Save & Apply"));
+
+        expect(mockSave).toHaveBeenCalled();
+        expect(mockClose).toHaveBeenCalled();
+
+        // Let's verify the calculated config values
+        const savedConfig = mockSave.mock.calls[0][0];
+        expect(savedConfig.imageData).toBe("data:image/png;base64,123");
+        expect(savedConfig.width).toBeGreaterThan(0);
+        expect(savedConfig.height).toBeGreaterThan(0);
+    });
+
+    it('fires close event when close button is clicked', async () => {
+        const mockClose = vi.fn();
+        const { container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, onclose: mockClose } });
+
+        // Find the close button (the one with CloseIcon)
+        const closeBtn = container.querySelector('button.text-neutral-500');
+        await fireEvent.click(closeBtn!);
+
+        expect(mockClose).toHaveBeenCalled();
+    });
+
+    it('calculates config correctly', async () => {
+        const mockSave = vi.fn();
+
+        const { getByText, container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test-id", name: "Test Map", width: 144, height: 144, x: 0, y: 0 }, onsave: mockSave } });
+
+        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
+        await waitFor(() => {
+            expect(getByText("Next")).toBeDefined();
+        });
+
+        const img = container.querySelector('img');
+        if (img) {
+            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
+            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
+            await fireEvent.load(img);
+        }
+
+        await fireEvent.click(getByText("Next"));
+        await waitFor(() => {
+            expect(getByText("Save & Apply")).toBeDefined();
+        });
+
+        await fireEvent.click(getByText("Save & Apply"));
+
+        const savedConfig = mockSave.mock.calls[0][0];
+        expect(savedConfig.id).toBe("test-id"); // Keeps existing id
+        expect(savedConfig.name).toBe("Test Map");
+        expect(savedConfig.width).toBeCloseTo(180, 4);
+        expect(savedConfig.height).toBeCloseTo(180, 4);
+        expect(savedConfig.x).toBeCloseTo(-18, 4);
+        expect(savedConfig.y).toBeCloseTo(162, 4);
+    });
+
+    it('image load error triggers alert', async () => {
+         const { container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
+
+         await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
+         await waitFor(() => {
+             expect(container.querySelector('img')).not.toBeNull();
+         });
+
+         const img = container.querySelector('img');
+         // Use fireEvent.error as we found earlier it threw if we didn't wait for img to render
+         if(img) {
+            await fireEvent.error(img);
+         }
+
+         expect(window.alert).toHaveBeenCalledWith("The image failed to load in the browser. It may be corrupted or an unsupported format.");
+    });
+});

--- a/src/lib/components/settings/CustomFieldWizard.test.ts
+++ b/src/lib/components/settings/CustomFieldWizard.test.ts
@@ -1,282 +1,415 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/svelte';
-import CustomFieldWizardWrapper from './CustomFieldWizardWrapper.svelte';
-import CustomFieldWizard from './CustomFieldWizard.svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import CustomFieldWizardWrapper from "./CustomFieldWizardWrapper.svelte";
+import CustomFieldWizard from "./CustomFieldWizard.svelte";
 
-describe('CustomFieldWizard', () => {
-    let originalFileReader: any;
-    let originalAlert: any;
+describe("CustomFieldWizard", () => {
+  let originalFileReader: any;
+  let originalAlert: any;
 
-    beforeEach(() => {
-        originalFileReader = window.FileReader;
-        originalAlert = window.alert;
-        window.alert = vi.fn();
+  beforeEach(() => {
+    originalFileReader = globalThis.FileReader;
+    originalAlert = globalThis.alert;
+    globalThis.alert = vi.fn();
 
-        // Mock pointer capture methods for jsdom
-        if (!Element.prototype.setPointerCapture) {
-            Element.prototype.setPointerCapture = vi.fn();
-        }
-        if (!Element.prototype.releasePointerCapture) {
-            Element.prototype.releasePointerCapture = vi.fn();
-        }
-        if (!Element.prototype.hasPointerCapture) {
-            Element.prototype.hasPointerCapture = vi.fn(() => true);
-        }
+    // Mock pointer capture methods for jsdom
+    if (!Element.prototype.setPointerCapture) {
+      Element.prototype.setPointerCapture = vi.fn();
+    }
+    if (!Element.prototype.releasePointerCapture) {
+      Element.prototype.releasePointerCapture = vi.fn();
+    }
+    if (!Element.prototype.hasPointerCapture) {
+      Element.prototype.hasPointerCapture = vi.fn(() => true);
+    }
+  });
+
+  afterEach(() => {
+    globalThis.FileReader = originalFileReader;
+    globalThis.alert = originalAlert;
+    vi.restoreAllMocks();
+  });
+
+  it("renders and shows initial step 1", () => {
+    const { getByText } = render(CustomFieldWizard, {
+      props: { isOpen: true },
+    });
+    expect(getByText("Custom Field Map Wizard")).toBeDefined();
+    expect(getByText("Upload a custom field map image")).toBeDefined();
+    expect(getByText("Select Image")).toBeDefined();
+  });
+
+  it("does not render when isOpen is false", () => {
+    const { queryByText } = render(CustomFieldWizard, {
+      props: { isOpen: false },
+    });
+    expect(queryByText("Custom Field Map Wizard")).toBeNull();
+  });
+
+  it("handles image upload success and goes to step 2", async () => {
+    const { container } = render(CustomFieldWizard, {
+      props: { isOpen: true },
     });
 
-    afterEach(() => {
-        window.FileReader = originalFileReader;
-        window.alert = originalAlert;
-        vi.restoreAllMocks();
+    // Mock FileReader
+    globalThis.FileReader = class FileReader {
+      onload: any;
+      readAsDataURL() {
+        this.result = "data:image/png;base64,dummy";
+        if (this.onload) this.onload();
+      }
+    } as any;
+
+    const input = container.querySelector("#wizard-image-input");
+    expect(input).not.toBeNull();
+
+    const file = new File(["dummy content"], "test.png", { type: "image/png" });
+    Object.defineProperty(input, "files", {
+      value: [file],
     });
 
-    it('renders and shows initial step 1', () => {
-        const { getByText } = render(CustomFieldWizard, { props: { isOpen: true } });
-        expect(getByText('Custom Field Map Wizard')).toBeDefined();
-        expect(getByText('Upload a custom field map image')).toBeDefined();
-        expect(getByText('Select Image')).toBeDefined();
+    await fireEvent.change(input!);
+
+    // Should move to step 2 automatically
+    await waitFor(() => {
+      // Check if step 2 handles are present
+      expect(container.querySelector(".cursor-ns-resize")).not.toBeNull();
+    });
+  });
+
+  it("handles image upload read failure", async () => {
+    const { container } = render(CustomFieldWizard, {
+      props: { isOpen: true },
     });
 
-    it('does not render when isOpen is false', () => {
-        const { queryByText } = render(CustomFieldWizard, { props: { isOpen: false } });
-        expect(queryByText('Custom Field Map Wizard')).toBeNull();
+    globalThis.FileReader = class FileReader {
+      onload: any;
+      readAsDataURL() {
+        this.result = null; // not a string
+        if (this.onload) this.onload();
+      }
+    } as any;
+
+    const input = container.querySelector("#wizard-image-input");
+    const file = new File(["dummy content"], "test.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+
+    await fireEvent.change(input!);
+
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      "Failed to read image file. Please try again.",
+    );
+  });
+
+  it("handles image upload error", async () => {
+    const { container } = render(CustomFieldWizard, {
+      props: { isOpen: true },
     });
 
-    it('handles image upload success and goes to step 2', async () => {
-        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+    globalThis.FileReader = class FileReader {
+      onerror: any;
+      error = { message: "Test error" };
+      readAsDataURL() {
+        if (this.onerror) this.onerror();
+      }
+    } as any;
 
-        // Mock FileReader
-        window.FileReader = class FileReader {
-            onload: any;
-            readAsDataURL() {
-                this.result = "data:image/png;base64,dummy";
-                if (this.onload) this.onload();
-            }
-        } as any;
+    const input = container.querySelector("#wizard-image-input");
+    const file = new File(["dummy content"], "test.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
 
-        const input = container.querySelector('#wizard-image-input');
-        expect(input).not.toBeNull();
+    await fireEvent.change(input!);
 
-        const file = new File(["dummy content"], "test.png", { type: "image/png" });
-        Object.defineProperty(input, 'files', {
-            value: [file]
-        });
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      "Error reading file: Test error",
+    );
+  });
 
-        await fireEvent.change(input!);
-
-        // Should move to step 2 automatically
-        await waitFor(() => {
-            // Check if step 2 handles are present
-            expect(container.querySelector('.cursor-ns-resize')).not.toBeNull();
-        });
+  it("can transition back and forth between steps using buttons", async () => {
+    const { getByText, container } = render(CustomFieldWizard, {
+      props: {
+        isOpen: true,
+        currentConfig: {
+          imageData: "data:image/png;base64,123",
+          id: "test",
+          name: "test",
+          width: 144,
+          height: 144,
+          x: 0,
+          y: 0,
+        },
+      },
     });
 
-    it('handles image upload read failure', async () => {
-        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+    // Step 1 check button
+    await fireEvent.click(
+      container.querySelector("button.mt-4.text-blue-600")!,
+    );
 
-        window.FileReader = class FileReader {
-            onload: any;
-            readAsDataURL() {
-                this.result = null; // not a string
-                if (this.onload) this.onload();
-            }
-        } as any;
-
-        const input = container.querySelector('#wizard-image-input');
-        const file = new File(["dummy content"], "test.png", { type: "image/png" });
-        Object.defineProperty(input, 'files', { value: [file] });
-
-        await fireEvent.change(input!);
-
-        expect(window.alert).toHaveBeenCalledWith("Failed to read image file. Please try again.");
+    // Step 2
+    await waitFor(() => {
+      expect(getByText("Next")).toBeDefined();
     });
 
-    it('handles image upload error', async () => {
-        const { container } = render(CustomFieldWizard, { props: { isOpen: true } });
+    const img = container.querySelector("img");
+    if (img) {
+      Object.defineProperty(img, "naturalWidth", {
+        get: () => 1000,
+        configurable: true,
+      });
+      Object.defineProperty(img, "naturalHeight", {
+        get: () => 1000,
+        configurable: true,
+      });
+      await fireEvent.load(img);
+    }
 
-        window.FileReader = class FileReader {
-            onerror: any;
-            error = { message: "Test error" };
-            readAsDataURL() {
-                if (this.onerror) this.onerror();
-            }
-        } as any;
-
-        const input = container.querySelector('#wizard-image-input');
-        const file = new File(["dummy content"], "test.png", { type: "image/png" });
-        Object.defineProperty(input, 'files', { value: [file] });
-
-        await fireEvent.change(input!);
-
-        expect(window.alert).toHaveBeenCalledWith("Error reading file: Test error");
+    // Click next -> Step 3
+    await fireEvent.click(getByText("Next"));
+    await waitFor(() => {
+      expect(getByText("Save & Apply")).toBeDefined();
     });
 
-    it('can transition back and forth between steps using buttons', async () => {
-        const { getByText, container } = render(CustomFieldWizard, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
+    // Click back -> Step 2
+    await fireEvent.click(getByText("Back"));
+    await waitFor(() => {
+      expect(getByText("Next")).toBeDefined();
+    });
+  });
 
-        // Step 1 check button
-        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
-
-        // Step 2
-        await waitFor(() => {
-            expect(getByText("Next")).toBeDefined();
-        });
-
-        const img = container.querySelector('img');
-        if (img) {
-            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
-            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
-            await fireEvent.load(img);
-        }
-
-        // Click next -> Step 3
-        await fireEvent.click(getByText("Next"));
-        await waitFor(() => {
-            expect(getByText("Save & Apply")).toBeDefined();
-        });
-
-        // Click back -> Step 2
-        await fireEvent.click(getByText("Back"));
-        await waitFor(() => {
-             expect(getByText("Next")).toBeDefined();
-        });
+  it("handles pointer events for dragging bounding box", async () => {
+    const { container } = render(CustomFieldWizard, {
+      props: {
+        isOpen: true,
+        currentConfig: {
+          imageData: "data:image/png;base64,123",
+          id: "test",
+          name: "test",
+          width: 144,
+          height: 144,
+          x: 0,
+          y: 0,
+        },
+      },
     });
 
-    it('handles pointer events for dragging bounding box', async () => {
-        const { container } = render(CustomFieldWizard, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
-
-        // Go to step 2
-        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
-        await waitFor(() => {
-            expect(container.querySelector('.cursor-move')).not.toBeNull();
-        });
-
-        const moveBox = container.querySelector('.cursor-move') as HTMLElement;
-
-        // Mock pointer events and getBoundingClientRect
-        const imageContainer = moveBox.parentElement;
-        if(imageContainer) {
-            imageContainer.getBoundingClientRect = () => ({ width: 1000, height: 1000, left: 0, top: 0, right: 1000, bottom: 1000, x: 0, y: 0, toJSON: () => {} } as DOMRect);
-        }
-
-        // Test pointer move
-        await fireEvent.pointerDown(moveBox, { clientX: 100, clientY: 100, pointerId: 1 });
-        await fireEvent.pointerMove(moveBox, { clientX: 200, clientY: 200 });
-        await fireEvent.pointerUp(moveBox, { pointerId: 1 });
-
-        // Box x/y should have changed (initially 0.1, 0.1, delta is 100/1000 = +0.1) -> 0.2
-        expect(moveBox.style.left).toBe('20%');
-        expect(moveBox.style.top).toBe('20%');
-
-        // Test pointer resize (W handle)
-        const wHandle = container.querySelector('.cursor-ew-resize') as HTMLElement; // Left handle
-        await fireEvent.pointerDown(wHandle, { clientX: 200, clientY: 200, pointerId: 2 });
-        // Move left by 100px (-0.1 relative)
-        await fireEvent.pointerMove(wHandle, { clientX: 100, clientY: 200 });
-        await fireEvent.pointerUp(wHandle, { pointerId: 2 });
-
-        // X should go back to 0.1, width should increase from 0.8 to 0.9
-        expect(moveBox.style.left).toBe('10%');
-        expect(moveBox.style.width).toBe('90%');
+    // Go to step 2
+    await fireEvent.click(
+      container.querySelector("button.mt-4.text-blue-600")!,
+    );
+    await waitFor(() => {
+      expect(container.querySelector(".cursor-move")).not.toBeNull();
     });
 
-    it('saves configuration and emits events', async () => {
-        const mockSave = vi.fn();
-        const mockClose = vi.fn();
+    const moveBox = container.querySelector(".cursor-move") as HTMLElement;
 
-        const { getByText, container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 }, onsave: mockSave, onclose: mockClose } });
+    // Mock pointer events and getBoundingClientRect
+    const imageContainer = moveBox.parentElement;
+    if (imageContainer) {
+      imageContainer.getBoundingClientRect = () =>
+        ({
+          width: 1000,
+          height: 1000,
+          left: 0,
+          top: 0,
+          right: 1000,
+          bottom: 1000,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        }) as DOMRect;
+    }
 
-        // Go to step 2
-        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
-        await waitFor(() => {
-            expect(getByText("Next")).toBeDefined();
-        });
+    // Test pointer move
+    await fireEvent.pointerDown(moveBox, {
+      clientX: 100,
+      clientY: 100,
+      pointerId: 1,
+    });
+    await fireEvent.pointerMove(moveBox, { clientX: 200, clientY: 200 });
+    await fireEvent.pointerUp(moveBox, { pointerId: 1 });
 
-        // Mock image dimensions
-        const img = container.querySelector('img');
-        if (img) {
-            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
-            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
-            await fireEvent.load(img);
-        }
+    // Box x/y should have changed (initially 0.1, 0.1, delta is 100/1000 = +0.1) -> 0.2
+    expect(moveBox.style.left).toBe("20%");
+    expect(moveBox.style.top).toBe("20%");
 
-        // Go to step 3
-        await fireEvent.click(getByText("Next"));
-        await waitFor(() => {
-            expect(getByText("Save & Apply")).toBeDefined();
-        });
+    // Test pointer resize (W handle)
+    const wHandle = container.querySelector(".cursor-ew-resize") as HTMLElement; // Left handle
+    await fireEvent.pointerDown(wHandle, {
+      clientX: 200,
+      clientY: 200,
+      pointerId: 2,
+    });
+    // Move left by 100px (-0.1 relative)
+    await fireEvent.pointerMove(wHandle, { clientX: 100, clientY: 200 });
+    await fireEvent.pointerUp(wHandle, { pointerId: 2 });
 
-        // Click save
-        await fireEvent.click(getByText("Save & Apply"));
+    // X should go back to 0.1, width should increase from 0.8 to 0.9
+    expect(moveBox.style.left).toBe("10%");
+    expect(moveBox.style.width).toBe("90%");
+  });
 
-        expect(mockSave).toHaveBeenCalled();
-        expect(mockClose).toHaveBeenCalled();
+  it("saves configuration and emits events", async () => {
+    const mockSave = vi.fn();
+    const mockClose = vi.fn();
 
-        // Let's verify the calculated config values
-        const savedConfig = mockSave.mock.calls[0][0];
-        expect(savedConfig.imageData).toBe("data:image/png;base64,123");
-        expect(savedConfig.width).toBeGreaterThan(0);
-        expect(savedConfig.height).toBeGreaterThan(0);
+    const { getByText, container } = render(CustomFieldWizardWrapper, {
+      props: {
+        isOpen: true,
+        currentConfig: {
+          imageData: "data:image/png;base64,123",
+          id: "test",
+          name: "test",
+          width: 144,
+          height: 144,
+          x: 0,
+          y: 0,
+        },
+        onsave: mockSave,
+        onclose: mockClose,
+      },
     });
 
-    it('fires close event when close button is clicked', async () => {
-        const mockClose = vi.fn();
-        const { container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, onclose: mockClose } });
-
-        // Find the close button (the one with CloseIcon)
-        const closeBtn = container.querySelector('button.text-neutral-500');
-        await fireEvent.click(closeBtn!);
-
-        expect(mockClose).toHaveBeenCalled();
+    // Go to step 2
+    await fireEvent.click(
+      container.querySelector("button.mt-4.text-blue-600")!,
+    );
+    await waitFor(() => {
+      expect(getByText("Next")).toBeDefined();
     });
 
-    it('calculates config correctly', async () => {
-        const mockSave = vi.fn();
+    // Mock image dimensions
+    const img = container.querySelector("img");
+    if (img) {
+      Object.defineProperty(img, "naturalWidth", {
+        get: () => 1000,
+        configurable: true,
+      });
+      Object.defineProperty(img, "naturalHeight", {
+        get: () => 1000,
+        configurable: true,
+      });
+      await fireEvent.load(img);
+    }
 
-        const { getByText, container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test-id", name: "Test Map", width: 144, height: 144, x: 0, y: 0 }, onsave: mockSave } });
-
-        await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
-        await waitFor(() => {
-            expect(getByText("Next")).toBeDefined();
-        });
-
-        const img = container.querySelector('img');
-        if (img) {
-            Object.defineProperty(img, 'naturalWidth', { get: () => 1000, configurable: true });
-            Object.defineProperty(img, 'naturalHeight', { get: () => 1000, configurable: true });
-            await fireEvent.load(img);
-        }
-
-        await fireEvent.click(getByText("Next"));
-        await waitFor(() => {
-            expect(getByText("Save & Apply")).toBeDefined();
-        });
-
-        await fireEvent.click(getByText("Save & Apply"));
-
-        const savedConfig = mockSave.mock.calls[0][0];
-        expect(savedConfig.id).toBe("test-id"); // Keeps existing id
-        expect(savedConfig.name).toBe("Test Map");
-        expect(savedConfig.width).toBeCloseTo(180, 4);
-        expect(savedConfig.height).toBeCloseTo(180, 4);
-        expect(savedConfig.x).toBeCloseTo(-18, 4);
-        expect(savedConfig.y).toBeCloseTo(162, 4);
+    // Go to step 3
+    await fireEvent.click(getByText("Next"));
+    await waitFor(() => {
+      expect(getByText("Save & Apply")).toBeDefined();
     });
 
-    it('image load error triggers alert', async () => {
-         const { container } = render(CustomFieldWizardWrapper, { props: { isOpen: true, currentConfig: { imageData: "data:image/png;base64,123", id: "test", name: "test", width: 144, height: 144, x: 0, y: 0 } } });
+    // Click save
+    await fireEvent.click(getByText("Save & Apply"));
 
-         await fireEvent.click(container.querySelector("button.mt-4.text-blue-600")!);
-         await waitFor(() => {
-             expect(container.querySelector('img')).not.toBeNull();
-         });
+    expect(mockSave).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
 
-         const img = container.querySelector('img');
-         // Use fireEvent.error as we found earlier it threw if we didn't wait for img to render
-         if(img) {
-            await fireEvent.error(img);
-         }
+    // Let's verify the calculated config values
+    const savedConfig = mockSave.mock.calls[0][0];
+    expect(savedConfig.imageData).toBe("data:image/png;base64,123");
+    expect(savedConfig.width).toBeGreaterThan(0);
+    expect(savedConfig.height).toBeGreaterThan(0);
+  });
 
-         expect(window.alert).toHaveBeenCalledWith("The image failed to load in the browser. It may be corrupted or an unsupported format.");
+  it("fires close event when close button is clicked", async () => {
+    const mockClose = vi.fn();
+    const { container } = render(CustomFieldWizardWrapper, {
+      props: { isOpen: true, onclose: mockClose },
     });
+
+    // Find the close button (the one with CloseIcon)
+    const closeBtn = container.querySelector("button.text-neutral-500");
+    await fireEvent.click(closeBtn!);
+
+    expect(mockClose).toHaveBeenCalled();
+  });
+
+  it("calculates config correctly", async () => {
+    const mockSave = vi.fn();
+
+    const { getByText, container } = render(CustomFieldWizardWrapper, {
+      props: {
+        isOpen: true,
+        currentConfig: {
+          imageData: "data:image/png;base64,123",
+          id: "test-id",
+          name: "Test Map",
+          width: 144,
+          height: 144,
+          x: 0,
+          y: 0,
+        },
+        onsave: mockSave,
+      },
+    });
+
+    await fireEvent.click(
+      container.querySelector("button.mt-4.text-blue-600")!,
+    );
+    await waitFor(() => {
+      expect(getByText("Next")).toBeDefined();
+    });
+
+    const img = container.querySelector("img");
+    if (img) {
+      Object.defineProperty(img, "naturalWidth", {
+        get: () => 1000,
+        configurable: true,
+      });
+      Object.defineProperty(img, "naturalHeight", {
+        get: () => 1000,
+        configurable: true,
+      });
+      await fireEvent.load(img);
+    }
+
+    await fireEvent.click(getByText("Next"));
+    await waitFor(() => {
+      expect(getByText("Save & Apply")).toBeDefined();
+    });
+
+    await fireEvent.click(getByText("Save & Apply"));
+
+    const savedConfig = mockSave.mock.calls[0][0];
+    expect(savedConfig.id).toBe("test-id"); // Keeps existing id
+    expect(savedConfig.name).toBe("Test Map");
+    expect(savedConfig.width).toBeCloseTo(180, 4);
+    expect(savedConfig.height).toBeCloseTo(180, 4);
+    expect(savedConfig.x).toBeCloseTo(-18, 4);
+    expect(savedConfig.y).toBeCloseTo(162, 4);
+  });
+
+  it("image load error triggers alert", async () => {
+    const { container } = render(CustomFieldWizardWrapper, {
+      props: {
+        isOpen: true,
+        currentConfig: {
+          imageData: "data:image/png;base64,123",
+          id: "test",
+          name: "test",
+          width: 144,
+          height: 144,
+          x: 0,
+          y: 0,
+        },
+      },
+    });
+
+    await fireEvent.click(
+      container.querySelector("button.mt-4.text-blue-600")!,
+    );
+    await waitFor(() => {
+      expect(container.querySelector("img")).not.toBeNull();
+    });
+
+    const img = container.querySelector("img");
+    // Use fireEvent.error as we found earlier it threw if we didn't wait for img to render
+    if (img) {
+      await fireEvent.error(img);
+    }
+
+    expect(globalThis.alert).toHaveBeenCalledWith(
+      "The image failed to load in the browser. It may be corrupted or an unsupported format.",
+    );
+  });
 });

--- a/src/lib/components/settings/CustomFieldWizardWrapper.svelte
+++ b/src/lib/components/settings/CustomFieldWizardWrapper.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+    import CustomFieldWizard from './CustomFieldWizard.svelte';
+    import type { CustomFieldConfig } from "../../../types";
+
+    export let isOpen = true;
+    export let currentConfig: CustomFieldConfig | undefined = undefined;
+
+    // Callbacks to simulate generic event listening with Svelte 5 properties pattern
+    export let onsave: ((config: any) => void) | undefined = undefined;
+    export let onclose: (() => void) | undefined = undefined;
+
+    let childProps = {
+        get isOpen() { return isOpen; },
+        set isOpen(v) { isOpen = v; },
+        currentConfig
+    };
+
+    function handleSave(e: CustomEvent) {
+        if(onsave) onsave(e.detail);
+    }
+
+    function handleClose() {
+        if(onclose) onclose();
+    }
+</script>
+
+<CustomFieldWizard
+    bind:isOpen={childProps.isOpen}
+    currentConfig={childProps.currentConfig}
+    on:close={handleClose}
+    on:save={handleSave}
+/>

--- a/src/lib/components/settings/CustomFieldWizardWrapper.svelte
+++ b/src/lib/components/settings/CustomFieldWizardWrapper.svelte
@@ -1,32 +1,36 @@
 <script lang="ts">
-    import CustomFieldWizard from './CustomFieldWizard.svelte';
-    import type { CustomFieldConfig } from "../../../types";
+  import CustomFieldWizard from "./CustomFieldWizard.svelte";
+  import type { CustomFieldConfig } from "../../../types";
 
-    export let isOpen = true;
-    export let currentConfig: CustomFieldConfig | undefined = undefined;
+  export let isOpen = true;
+  export let currentConfig: CustomFieldConfig | undefined = undefined;
 
-    // Callbacks to simulate generic event listening with Svelte 5 properties pattern
-    export let onsave: ((config: any) => void) | undefined = undefined;
-    export let onclose: (() => void) | undefined = undefined;
+  // Callbacks to simulate generic event listening with Svelte 5 properties pattern
+  export let onsave: ((config: any) => void) | undefined = undefined;
+  export let onclose: (() => void) | undefined = undefined;
 
-    let childProps = {
-        get isOpen() { return isOpen; },
-        set isOpen(v) { isOpen = v; },
-        currentConfig
-    };
+  let childProps = {
+    get isOpen() {
+      return isOpen;
+    },
+    set isOpen(v) {
+      isOpen = v;
+    },
+    currentConfig,
+  };
 
-    function handleSave(e: CustomEvent) {
-        if(onsave) onsave(e.detail);
-    }
+  function handleSave(e: CustomEvent) {
+    if (onsave) onsave(e.detail);
+  }
 
-    function handleClose() {
-        if(onclose) onclose();
-    }
+  function handleClose() {
+    if (onclose) onclose();
+  }
 </script>
 
 <CustomFieldWizard
-    bind:isOpen={childProps.isOpen}
-    currentConfig={childProps.currentConfig}
-    on:close={handleClose}
-    on:save={handleSave}
+  bind:isOpen={childProps.isOpen}
+  currentConfig={childProps.currentConfig}
+  on:close={handleClose}
+  on:save={handleSave}
 />

--- a/src/lib/components/settings/RobotProfileManager.test.ts
+++ b/src/lib/components/settings/RobotProfileManager.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, fireEvent, waitFor } from '@testing-library/svelte';
+import RobotProfileManagerWrapper from './RobotProfileManagerWrapper.svelte';
+import { robotProfilesStore } from "../../../lib/projectStore";
+import { notification } from "../../../stores";
+
+vi.mock("../../../lib/projectStore", () => ({
+    robotProfilesStore: {
+        subscribe: vi.fn(),
+        update: vi.fn(),
+        set: vi.fn()
+    }
+}));
+
+vi.mock("../../../stores", () => ({
+    notification: {
+        set: vi.fn()
+    }
+}));
+
+describe('RobotProfileManager', () => {
+    let mockProfiles: any[] = [];
+    let subscriber: any;
+
+    const baseSettings = {
+        rLength: 10,
+        rWidth: 10,
+        maxVelocity: 50,
+        maxAcceleration: 50,
+        maxDeceleration: 50,
+        maxAngularAcceleration: 50,
+        kFriction: 1,
+        aVelocity: 1,
+        xVelocity: 1,
+        yVelocity: 1,
+        showRobotArrows: true,
+        showFakeHeadingArrow: false,
+        fakeHeadingArrowColor: "#ff0000"
+    };
+
+    beforeEach(() => {
+        mockProfiles = [];
+        vi.mocked(robotProfilesStore.subscribe).mockImplementation((cb) => {
+            subscriber = cb;
+            cb(mockProfiles);
+            return () => {};
+        });
+        vi.mocked(robotProfilesStore.update).mockImplementation((cb) => {
+            mockProfiles = cb(mockProfiles);
+            if (subscriber) subscriber(mockProfiles);
+        });
+        vi.mocked(robotProfilesStore.set).mockImplementation((v) => {
+            mockProfiles = v;
+            if (subscriber) subscriber(mockProfiles);
+        });
+
+        // Mock window.confirm
+        window.confirm = vi.fn(() => true);
+        window.URL.createObjectURL = vi.fn(() => 'mock-url');
+        window.URL.revokeObjectURL = vi.fn();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders empty state correctly', () => {
+        const { getByText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+        expect(getByText('Robot Profiles')).toBeDefined();
+        expect(getByText('No saved profiles yet.')).toBeDefined();
+        expect(getByText('+ New Profile')).toBeDefined();
+    });
+
+    it('handles creating a new profile', async () => {
+        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        // Click new profile
+        await fireEvent.click(getByText('+ New Profile'));
+
+        const input = container.querySelector('#profile-name') as HTMLInputElement;
+        await fireEvent.input(input, { target: { value: 'My Robot' } });
+
+        // Save (button text: "Save Current Settings")
+        const saveBtn = getByText('Save Current Settings');
+        await fireEvent.click(saveBtn);
+
+        expect(mockProfiles.length).toBe(1);
+        expect(mockProfiles[0].name).toBe('My Robot');
+        expect(mockProfiles[0].rLength).toBe(10);
+        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "My Robot" created', type: 'success' });
+    });
+
+    it('requires a profile name when creating', async () => {
+        const { getByText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        // Click new profile
+        await fireEvent.click(getByText('+ New Profile'));
+
+        // Save without typing name
+        const saveBtn = getByText('Save Current Settings');
+        await fireEvent.click(saveBtn);
+
+        expect(mockProfiles.length).toBe(0);
+        expect(notification.set).toHaveBeenCalledWith({ message: 'Please enter a profile name', type: 'warning' });
+    });
+
+    it('displays profiles and can load them', async () => {
+        mockProfiles = [
+            { id: '1', name: 'Profile 1', maxVelocity: 100 },
+            { id: '2', name: 'Profile 2', maxVelocity: 200 }
+        ];
+
+        const mockSettingsChange = vi.fn();
+        const settings = { ...baseSettings };
+        const { getByText, getByRole } = render(RobotProfileManagerWrapper, { props: { settings, onSettingsChange: mockSettingsChange } });
+
+        const select = getByRole('combobox');
+
+        // Select profile 2
+        await fireEvent.change(select, { target: { value: '2' } });
+
+        // Load profile 2
+        const loadBtn = getByText('Load');
+        await fireEvent.click(loadBtn);
+
+        expect(window.confirm).toHaveBeenCalled();
+        expect(settings.maxVelocity).toBe(200);
+        expect(mockSettingsChange).toHaveBeenCalled();
+        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 2" applied', type: 'success' });
+    });
+
+    it('can delete profile', async () => {
+        mockProfiles = [
+            { id: '1', name: 'Profile 1' },
+            { id: '2', name: 'Profile 2' }
+        ];
+
+        const { getByRole, getByTitle, getByLabelText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        const select = getByRole('combobox');
+        await fireEvent.change(select, { target: { value: '1' } });
+
+        const deleteBtn = getByTitle('Delete Profile');
+        await fireEvent.click(deleteBtn);
+
+        await waitFor(() => {
+             expect(getByLabelText("Confirm Deletion")).toBeDefined();
+        });
+
+        const confirmBtn = getByLabelText("Confirm Deletion");
+        await fireEvent.click(confirmBtn);
+
+        expect(mockProfiles.length).toBe(1);
+        expect(mockProfiles[0].id).toBe('2');
+        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 1" deleted', type: 'success' });
+    });
+
+    it('can update profile with current settings', async () => {
+        mockProfiles = [
+            { id: '1', name: 'Profile 1', maxVelocity: 100 },
+            { id: '2', name: 'Profile 2', maxVelocity: 200 }
+        ];
+
+        // Settings has maxVelocity = 50
+        const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        const select = getByRole('combobox');
+        await fireEvent.change(select, { target: { value: '1' } });
+
+        const updateBtn = getByTitle('Overwrite profile with current settings');
+
+        // First click shows confirmation state
+        await fireEvent.click(updateBtn);
+
+        // Second click updates
+        await fireEvent.click(updateBtn);
+
+        expect(mockProfiles[0].maxVelocity).toBe(50);
+        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 1" updated', type: 'success' });
+    });
+
+    it('can export profile', async () => {
+        mockProfiles = [
+            { id: '1', name: 'Profile 1', maxVelocity: 100 }
+        ];
+
+        const mockLink = {
+            href: '',
+            download: '',
+            click: vi.fn(),
+            remove: vi.fn(),
+            setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
+        };
+        const origCreateElement = document.createElement.bind(document);
+        vi.spyOn(document, "createElement").mockImplementation((tag) => tag === "a" ? mockLink as any : origCreateElement(tag));
+
+        const origAppendChild = document.body.appendChild.bind(document.body);
+        vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
+            if(node === mockLink) return node as any;
+            return origAppendChild(node);
+        });
+
+        const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        const select = getByRole('combobox');
+        await fireEvent.change(select, { target: { value: '1' } });
+
+        const exportBtn = getByTitle('Export Profile');
+        await fireEvent.click(exportBtn);
+
+        expect(mockLink.download).toBe('robot-profile-profile_1.json');
+        expect(mockLink.href).toBe('mock-url');
+        expect(mockLink.click).toHaveBeenCalled();
+    });
+
+    it('handles import profile', async () => {
+        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        const originalFileReader = window.FileReader;
+        window.FileReader = class FileReader {
+            onload: any;
+            readAsText() {
+                this.onload({ target: { result: JSON.stringify({ name: "Imported Robot", maxVelocity: 300 }) } });
+            }
+        } as any;
+
+        const input = container.querySelector('#profile-import-input') as HTMLInputElement;
+        const file = new File(["dummy"], "profile.json", { type: "application/json" });
+        Object.defineProperty(input, 'files', { value: [file] });
+
+        await fireEvent.change(input);
+
+        expect(mockProfiles.length).toBe(1);
+        expect(mockProfiles[0].name).toBe("Imported Robot (Imported)");
+        expect(mockProfiles[0].maxVelocity).toBe(300);
+        expect(notification.set).toHaveBeenCalledWith({ message: `Profile "Imported Robot (Imported)" imported successfully`, type: "success", timeout: 3000 });
+
+        window.FileReader = originalFileReader;
+    });
+
+    it('handles import profile validation error', async () => {
+        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
+
+        const originalFileReader = window.FileReader;
+        window.FileReader = class FileReader {
+            onload: any;
+            readAsText() {
+                this.onload({ target: { result: JSON.stringify({ name: "Imported Robot" }) } });
+            }
+        } as any;
+
+        const input = container.querySelector('#profile-import-input') as HTMLInputElement;
+        const file = new File(["dummy"], "profile.json", { type: "application/json" });
+        Object.defineProperty(input, 'files', { value: [file] });
+
+        await fireEvent.change(input);
+
+        expect(mockProfiles.length).toBe(0);
+        expect(notification.set).toHaveBeenCalledWith({ message: "Error importing profile: Invalid robot profile format.", type: "error" });
+
+        window.FileReader = originalFileReader;
+    });
+});

--- a/src/lib/components/settings/RobotProfileManager.test.ts
+++ b/src/lib/components/settings/RobotProfileManager.test.ts
@@ -1,263 +1,324 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/svelte';
-import RobotProfileManagerWrapper from './RobotProfileManagerWrapper.svelte';
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, fireEvent, waitFor } from "@testing-library/svelte";
+import RobotProfileManagerWrapper from "./RobotProfileManagerWrapper.svelte";
 import { robotProfilesStore } from "../../../lib/projectStore";
 import { notification } from "../../../stores";
 
 vi.mock("../../../lib/projectStore", () => ({
-    robotProfilesStore: {
-        subscribe: vi.fn(),
-        update: vi.fn(),
-        set: vi.fn()
-    }
+  robotProfilesStore: {
+    subscribe: vi.fn(),
+    update: vi.fn(),
+    set: vi.fn(),
+  },
 }));
 
 vi.mock("../../../stores", () => ({
-    notification: {
-        set: vi.fn()
-    }
+  notification: {
+    set: vi.fn(),
+  },
 }));
 
-describe('RobotProfileManager', () => {
-    let mockProfiles: any[] = [];
-    let subscriber: any;
+describe("RobotProfileManager", () => {
+  let mockProfiles: any[] = [];
+  let subscriber: any;
 
-    const baseSettings = {
-        rLength: 10,
-        rWidth: 10,
-        maxVelocity: 50,
-        maxAcceleration: 50,
-        maxDeceleration: 50,
-        maxAngularAcceleration: 50,
-        kFriction: 1,
-        aVelocity: 1,
-        xVelocity: 1,
-        yVelocity: 1,
-        showRobotArrows: true,
-        showFakeHeadingArrow: false,
-        fakeHeadingArrowColor: "#ff0000"
+  const baseSettings = {
+    rLength: 10,
+    rWidth: 10,
+    maxVelocity: 50,
+    maxAcceleration: 50,
+    maxDeceleration: 50,
+    maxAngularAcceleration: 50,
+    kFriction: 1,
+    aVelocity: 1,
+    xVelocity: 1,
+    yVelocity: 1,
+    showRobotArrows: true,
+    showFakeHeadingArrow: false,
+    fakeHeadingArrowColor: "#ff0000",
+  };
+
+  beforeEach(() => {
+    mockProfiles = [];
+    vi.mocked(robotProfilesStore.subscribe).mockImplementation((cb) => {
+      subscriber = cb;
+      cb(mockProfiles);
+      return () => {};
+    });
+    vi.mocked(robotProfilesStore.update).mockImplementation((cb) => {
+      mockProfiles = cb(mockProfiles);
+      if (subscriber) subscriber(mockProfiles);
+    });
+    vi.mocked(robotProfilesStore.set).mockImplementation((v) => {
+      mockProfiles = v;
+      if (subscriber) subscriber(mockProfiles);
+    });
+
+    // Mock window.confirm
+    globalThis.confirm = vi.fn(() => true);
+    globalThis.URL.createObjectURL = vi.fn(() => "mock-url");
+    globalThis.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state correctly", () => {
+    const { getByText } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+    expect(getByText("Robot Profiles")).toBeDefined();
+    expect(getByText("No saved profiles yet.")).toBeDefined();
+    expect(getByText("+ New Profile")).toBeDefined();
+  });
+
+  it("handles creating a new profile", async () => {
+    const { getByText, container } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    // Click new profile
+    await fireEvent.click(getByText("+ New Profile"));
+
+    const input = container.querySelector("#profile-name") as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: "My Robot" } });
+
+    // Save (button text: "Save Current Settings")
+    const saveBtn = getByText("Save Current Settings");
+    await fireEvent.click(saveBtn);
+
+    expect(mockProfiles.length).toBe(1);
+    expect(mockProfiles[0].name).toBe("My Robot");
+    expect(mockProfiles[0].rLength).toBe(10);
+    expect(notification.set).toHaveBeenCalledWith({
+      message: 'Profile "My Robot" created',
+      type: "success",
+    });
+  });
+
+  it("requires a profile name when creating", async () => {
+    const { getByText } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    // Click new profile
+    await fireEvent.click(getByText("+ New Profile"));
+
+    // Save without typing name
+    const saveBtn = getByText("Save Current Settings");
+    await fireEvent.click(saveBtn);
+
+    expect(mockProfiles.length).toBe(0);
+    expect(notification.set).toHaveBeenCalledWith({
+      message: "Please enter a profile name",
+      type: "warning",
+    });
+  });
+
+  it("displays profiles and can load them", async () => {
+    mockProfiles = [
+      { id: "1", name: "Profile 1", maxVelocity: 100 },
+      { id: "2", name: "Profile 2", maxVelocity: 200 },
+    ];
+
+    const mockSettingsChange = vi.fn();
+    const settings = { ...baseSettings };
+    const { getByText, getByRole } = render(RobotProfileManagerWrapper, {
+      props: { settings, onSettingsChange: mockSettingsChange },
+    });
+
+    const select = getByRole("combobox");
+
+    // Select profile 2
+    await fireEvent.change(select, { target: { value: "2" } });
+
+    // Load profile 2
+    const loadBtn = getByText("Load");
+    await fireEvent.click(loadBtn);
+
+    expect(globalThis.confirm).toHaveBeenCalled();
+    expect(settings.maxVelocity).toBe(200);
+    expect(mockSettingsChange).toHaveBeenCalled();
+    expect(notification.set).toHaveBeenCalledWith({
+      message: 'Profile "Profile 2" applied',
+      type: "success",
+    });
+  });
+
+  it("can delete profile", async () => {
+    mockProfiles = [
+      { id: "1", name: "Profile 1" },
+      { id: "2", name: "Profile 2" },
+    ];
+
+    const { getByRole, getByTitle, getByLabelText } = render(
+      RobotProfileManagerWrapper,
+      { props: { settings: { ...baseSettings } } },
+    );
+
+    const select = getByRole("combobox");
+    await fireEvent.change(select, { target: { value: "1" } });
+
+    const deleteBtn = getByTitle("Delete Profile");
+    await fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(getByLabelText("Confirm Deletion")).toBeDefined();
+    });
+
+    const confirmBtn = getByLabelText("Confirm Deletion");
+    await fireEvent.click(confirmBtn);
+
+    expect(mockProfiles.length).toBe(1);
+    expect(mockProfiles[0].id).toBe("2");
+    expect(notification.set).toHaveBeenCalledWith({
+      message: 'Profile "Profile 1" deleted',
+      type: "success",
+    });
+  });
+
+  it("can update profile with current settings", async () => {
+    mockProfiles = [
+      { id: "1", name: "Profile 1", maxVelocity: 100 },
+      { id: "2", name: "Profile 2", maxVelocity: 200 },
+    ];
+
+    // Settings has maxVelocity = 50
+    const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    const select = getByRole("combobox");
+    await fireEvent.change(select, { target: { value: "1" } });
+
+    const updateBtn = getByTitle("Overwrite profile with current settings");
+
+    // First click shows confirmation state
+    await fireEvent.click(updateBtn);
+
+    // Second click updates
+    await fireEvent.click(updateBtn);
+
+    expect(mockProfiles[0].maxVelocity).toBe(50);
+    expect(notification.set).toHaveBeenCalledWith({
+      message: 'Profile "Profile 1" updated',
+      type: "success",
+    });
+  });
+
+  it("can export profile", async () => {
+    mockProfiles = [{ id: "1", name: "Profile 1", maxVelocity: 100 }];
+
+    const mockLink = {
+      href: "",
+      download: "",
+      click: vi.fn(),
+      remove: vi.fn(),
+      setAttribute: function (k: string, v: string) {
+        (this as any)[k] = v;
+      },
     };
+    const origCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag) =>
+      tag === "a" ? (mockLink as any) : origCreateElement(tag),
+    );
 
-    beforeEach(() => {
-        mockProfiles = [];
-        vi.mocked(robotProfilesStore.subscribe).mockImplementation((cb) => {
-            subscriber = cb;
-            cb(mockProfiles);
-            return () => {};
+    const origAppendChild = document.body.appendChild.bind(document.body);
+    vi.spyOn(document.body, "appendChild").mockImplementation((node) => {
+      if (node === mockLink) return node as any;
+      return origAppendChild(node);
+    });
+
+    const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    const select = getByRole("combobox");
+    await fireEvent.change(select, { target: { value: "1" } });
+
+    const exportBtn = getByTitle("Export Profile");
+    await fireEvent.click(exportBtn);
+
+    expect(mockLink.download).toBe("robot-profile-profile_1.json");
+    expect(mockLink.href).toBe("mock-url");
+    expect(document.body.appendChild).toHaveBeenCalledWith(mockLink);
+    expect(mockLink.click).toHaveBeenCalled();
+  });
+
+  it("handles import profile", async () => {
+    const { getByText, container } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    const originalFileReader = globalThis.FileReader;
+    globalThis.FileReader = class FileReader {
+      onload: any;
+      readAsText() {
+        this.onload({
+          target: {
+            result: JSON.stringify({
+              name: "Imported Robot",
+              maxVelocity: 300,
+            }),
+          },
         });
-        vi.mocked(robotProfilesStore.update).mockImplementation((cb) => {
-            mockProfiles = cb(mockProfiles);
-            if (subscriber) subscriber(mockProfiles);
+      }
+    } as any;
+
+    const input = container.querySelector(
+      "#profile-import-input",
+    ) as HTMLInputElement;
+    const file = new File(["dummy"], "profile.json", {
+      type: "application/json",
+    });
+    Object.defineProperty(input, "files", { value: [file] });
+
+    await fireEvent.change(input);
+
+    expect(mockProfiles.length).toBe(1);
+    expect(mockProfiles[0].name).toBe("Imported Robot (Imported)");
+    expect(mockProfiles[0].maxVelocity).toBe(300);
+    expect(notification.set).toHaveBeenCalledWith({
+      message: `Profile "Imported Robot (Imported)" imported successfully`,
+      type: "success",
+      timeout: 3000,
+    });
+
+    globalThis.FileReader = originalFileReader;
+  });
+
+  it("handles import profile validation error", async () => {
+    const { getByText, container } = render(RobotProfileManagerWrapper, {
+      props: { settings: { ...baseSettings } },
+    });
+
+    const originalFileReader = globalThis.FileReader;
+    globalThis.FileReader = class FileReader {
+      onload: any;
+      readAsText() {
+        this.onload({
+          target: { result: JSON.stringify({ name: "Imported Robot" }) },
         });
-        vi.mocked(robotProfilesStore.set).mockImplementation((v) => {
-            mockProfiles = v;
-            if (subscriber) subscriber(mockProfiles);
-        });
+      }
+    } as any;
 
-        // Mock window.confirm
-        window.confirm = vi.fn(() => true);
-        window.URL.createObjectURL = vi.fn(() => 'mock-url');
-        window.URL.revokeObjectURL = vi.fn();
+    const input = container.querySelector(
+      "#profile-import-input",
+    ) as HTMLInputElement;
+    const file = new File(["dummy"], "profile.json", {
+      type: "application/json",
+    });
+    Object.defineProperty(input, "files", { value: [file] });
+
+    await fireEvent.change(input);
+
+    expect(mockProfiles.length).toBe(0);
+    expect(notification.set).toHaveBeenCalledWith({
+      message: "Error importing profile: Invalid robot profile format.",
+      type: "error",
     });
 
-    afterEach(() => {
-        vi.clearAllMocks();
-    });
-
-    it('renders empty state correctly', () => {
-        const { getByText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-        expect(getByText('Robot Profiles')).toBeDefined();
-        expect(getByText('No saved profiles yet.')).toBeDefined();
-        expect(getByText('+ New Profile')).toBeDefined();
-    });
-
-    it('handles creating a new profile', async () => {
-        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        // Click new profile
-        await fireEvent.click(getByText('+ New Profile'));
-
-        const input = container.querySelector('#profile-name') as HTMLInputElement;
-        await fireEvent.input(input, { target: { value: 'My Robot' } });
-
-        // Save (button text: "Save Current Settings")
-        const saveBtn = getByText('Save Current Settings');
-        await fireEvent.click(saveBtn);
-
-        expect(mockProfiles.length).toBe(1);
-        expect(mockProfiles[0].name).toBe('My Robot');
-        expect(mockProfiles[0].rLength).toBe(10);
-        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "My Robot" created', type: 'success' });
-    });
-
-    it('requires a profile name when creating', async () => {
-        const { getByText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        // Click new profile
-        await fireEvent.click(getByText('+ New Profile'));
-
-        // Save without typing name
-        const saveBtn = getByText('Save Current Settings');
-        await fireEvent.click(saveBtn);
-
-        expect(mockProfiles.length).toBe(0);
-        expect(notification.set).toHaveBeenCalledWith({ message: 'Please enter a profile name', type: 'warning' });
-    });
-
-    it('displays profiles and can load them', async () => {
-        mockProfiles = [
-            { id: '1', name: 'Profile 1', maxVelocity: 100 },
-            { id: '2', name: 'Profile 2', maxVelocity: 200 }
-        ];
-
-        const mockSettingsChange = vi.fn();
-        const settings = { ...baseSettings };
-        const { getByText, getByRole } = render(RobotProfileManagerWrapper, { props: { settings, onSettingsChange: mockSettingsChange } });
-
-        const select = getByRole('combobox');
-
-        // Select profile 2
-        await fireEvent.change(select, { target: { value: '2' } });
-
-        // Load profile 2
-        const loadBtn = getByText('Load');
-        await fireEvent.click(loadBtn);
-
-        expect(window.confirm).toHaveBeenCalled();
-        expect(settings.maxVelocity).toBe(200);
-        expect(mockSettingsChange).toHaveBeenCalled();
-        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 2" applied', type: 'success' });
-    });
-
-    it('can delete profile', async () => {
-        mockProfiles = [
-            { id: '1', name: 'Profile 1' },
-            { id: '2', name: 'Profile 2' }
-        ];
-
-        const { getByRole, getByTitle, getByLabelText } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        const select = getByRole('combobox');
-        await fireEvent.change(select, { target: { value: '1' } });
-
-        const deleteBtn = getByTitle('Delete Profile');
-        await fireEvent.click(deleteBtn);
-
-        await waitFor(() => {
-             expect(getByLabelText("Confirm Deletion")).toBeDefined();
-        });
-
-        const confirmBtn = getByLabelText("Confirm Deletion");
-        await fireEvent.click(confirmBtn);
-
-        expect(mockProfiles.length).toBe(1);
-        expect(mockProfiles[0].id).toBe('2');
-        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 1" deleted', type: 'success' });
-    });
-
-    it('can update profile with current settings', async () => {
-        mockProfiles = [
-            { id: '1', name: 'Profile 1', maxVelocity: 100 },
-            { id: '2', name: 'Profile 2', maxVelocity: 200 }
-        ];
-
-        // Settings has maxVelocity = 50
-        const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        const select = getByRole('combobox');
-        await fireEvent.change(select, { target: { value: '1' } });
-
-        const updateBtn = getByTitle('Overwrite profile with current settings');
-
-        // First click shows confirmation state
-        await fireEvent.click(updateBtn);
-
-        // Second click updates
-        await fireEvent.click(updateBtn);
-
-        expect(mockProfiles[0].maxVelocity).toBe(50);
-        expect(notification.set).toHaveBeenCalledWith({ message: 'Profile "Profile 1" updated', type: 'success' });
-    });
-
-    it('can export profile', async () => {
-        mockProfiles = [
-            { id: '1', name: 'Profile 1', maxVelocity: 100 }
-        ];
-
-        const mockLink = {
-            href: '',
-            download: '',
-            click: vi.fn(),
-            remove: vi.fn(),
-            setAttribute: function(k: string, v: string) { (this as any)[k] = v; }
-        };
-        const origCreateElement = document.createElement.bind(document);
-        vi.spyOn(document, "createElement").mockImplementation((tag) => tag === "a" ? mockLink as any : origCreateElement(tag));
-
-        const origAppendChild = document.body.appendChild.bind(document.body);
-        vi.spyOn(document.body, 'appendChild').mockImplementation((node) => {
-            if(node === mockLink) return node as any;
-            return origAppendChild(node);
-        });
-
-        const { getByRole, getByTitle } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        const select = getByRole('combobox');
-        await fireEvent.change(select, { target: { value: '1' } });
-
-        const exportBtn = getByTitle('Export Profile');
-        await fireEvent.click(exportBtn);
-
-        expect(mockLink.download).toBe('robot-profile-profile_1.json');
-        expect(mockLink.href).toBe('mock-url');
-        expect(mockLink.click).toHaveBeenCalled();
-    });
-
-    it('handles import profile', async () => {
-        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        const originalFileReader = window.FileReader;
-        window.FileReader = class FileReader {
-            onload: any;
-            readAsText() {
-                this.onload({ target: { result: JSON.stringify({ name: "Imported Robot", maxVelocity: 300 }) } });
-            }
-        } as any;
-
-        const input = container.querySelector('#profile-import-input') as HTMLInputElement;
-        const file = new File(["dummy"], "profile.json", { type: "application/json" });
-        Object.defineProperty(input, 'files', { value: [file] });
-
-        await fireEvent.change(input);
-
-        expect(mockProfiles.length).toBe(1);
-        expect(mockProfiles[0].name).toBe("Imported Robot (Imported)");
-        expect(mockProfiles[0].maxVelocity).toBe(300);
-        expect(notification.set).toHaveBeenCalledWith({ message: `Profile "Imported Robot (Imported)" imported successfully`, type: "success", timeout: 3000 });
-
-        window.FileReader = originalFileReader;
-    });
-
-    it('handles import profile validation error', async () => {
-        const { getByText, container } = render(RobotProfileManagerWrapper, { props: { settings: { ...baseSettings } } });
-
-        const originalFileReader = window.FileReader;
-        window.FileReader = class FileReader {
-            onload: any;
-            readAsText() {
-                this.onload({ target: { result: JSON.stringify({ name: "Imported Robot" }) } });
-            }
-        } as any;
-
-        const input = container.querySelector('#profile-import-input') as HTMLInputElement;
-        const file = new File(["dummy"], "profile.json", { type: "application/json" });
-        Object.defineProperty(input, 'files', { value: [file] });
-
-        await fireEvent.change(input);
-
-        expect(mockProfiles.length).toBe(0);
-        expect(notification.set).toHaveBeenCalledWith({ message: "Error importing profile: Invalid robot profile format.", type: "error" });
-
-        window.FileReader = originalFileReader;
-    });
+    globalThis.FileReader = originalFileReader;
+  });
 });

--- a/src/lib/components/settings/RobotProfileManagerWrapper.svelte
+++ b/src/lib/components/settings/RobotProfileManagerWrapper.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import RobotProfileManager from './RobotProfileManager.svelte';
+    import type { Settings } from "../../../types";
+
+    export let settings: Settings;
+    export let onSettingsChange: () => void = () => {};
+
+    let childProps = {
+        get settings() { return settings; },
+        set settings(v) { settings = v; },
+        onSettingsChange
+    };
+</script>
+
+<RobotProfileManager
+    bind:settings={childProps.settings}
+    onSettingsChange={childProps.onSettingsChange}
+/>

--- a/src/lib/components/settings/RobotProfileManagerWrapper.svelte
+++ b/src/lib/components/settings/RobotProfileManagerWrapper.svelte
@@ -1,18 +1,22 @@
 <script lang="ts">
-    import RobotProfileManager from './RobotProfileManager.svelte';
-    import type { Settings } from "../../../types";
+  import RobotProfileManager from "./RobotProfileManager.svelte";
+  import type { Settings } from "../../../types";
 
-    export let settings: Settings;
-    export let onSettingsChange: () => void = () => {};
+  export let settings: Settings;
+  export let onSettingsChange: () => void = () => {};
 
-    let childProps = {
-        get settings() { return settings; },
-        set settings(v) { settings = v; },
-        onSettingsChange
-    };
+  let childProps = {
+    get settings() {
+      return settings;
+    },
+    set settings(v) {
+      settings = v;
+    },
+    onSettingsChange,
+  };
 </script>
 
 <RobotProfileManager
-    bind:settings={childProps.settings}
-    onSettingsChange={childProps.onSettingsChange}
+  bind:settings={childProps.settings}
+  onSettingsChange={childProps.onSettingsChange}
 />


### PR DESCRIPTION
Adds extensive unit tests to `CustomFieldWizard.svelte` and `RobotProfileManager.svelte`.

Tests for `CustomFieldWizard` include:
- Component rendering and initial state
- Image uploading and FileReader mocks (both success and error states)
- Stepping backward and forward through the wizard (Next/Back)
- Bounding box configuration map offset recalculations based on mocked pointer dragging
- Save event emission and close event checks

Tests for `RobotProfileManager` include:
- Rendering profiles and checking empty states
- Creating profiles with validation (name required)
- Deleting, Loading, Updating, and Exporting profiles using JS-DOM mocks (e.g., `document.createElement('a')` overrides)
- Importing profiles parsing via FileReader mock with success/error paths

Also implements `RobotProfileManagerWrapper` and `CustomFieldWizardWrapper` specifically to allow `@testing-library/svelte` to inject and interact with Svelte 5 `$bindable` props correctly within Vitest.

---
*PR created automatically by Jules for task [3204426974169611101](https://jules.google.com/task/3204426974169611101) started by @Mallen220*