### PR TITLE
chore: Exclude scripts from coverage

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     include: ["src/**/*.{test,spec}.{js,ts}"],
     coverage: {
       reporter: ["text", "json", "json-summary", "html", "lcov"],
-      exclude: ["src/setupTests.ts", "src/tests/**", "src/**/*.d.ts"],
+      exclude: ["src/setupTests.ts", "src/tests/**", "src/**/*.d.ts", "scripts/**"],
     },
   },
   resolve: {


### PR DESCRIPTION
This PR addresses an issue where the test coverage runner was checking for test coverage inside the `scripts/` directory and reporting them as missing tests. The solution was simply to exclude `"scripts/**"` inside the `vitest.config.ts`'s `coverage.exclude` array, avoiding the introduction of useless dummy tests that would pollute the codebase.

---
*PR created automatically by Jules for task [11110580607108479828](https://jules.google.com/task/11110580607108479828) started by @Mallen220*