### PR TITLE
Migrate tabs code from Svelte 4 to Svelte 5

### DIFF
--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import type {
     Point,
@@ -88,7 +88,7 @@
   let targetLibrary: "SolversLib" | "NextFTC" = $state("SolversLib");
 
   // Sync state with settings
-  run(() => {
+  $effect(() => {
     if (settings) {
       if (settings.autoExportFormat) {
         format = settings.autoExportFormat;
@@ -253,7 +253,7 @@
 
   // Trigger update when dependencies change
   // Trigger update when dependencies change
-  run(() => {
+  $effect(() => {
     // Deeply track dependencies in Svelte 5
     $state.snapshot(startPoint);
     $state.snapshot(lines);

--- a/src/lib/components/tabs/FieldTab.svelte
+++ b/src/lib/components/tabs/FieldTab.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import type {
     Point,
@@ -58,7 +58,7 @@
     optimizerSection: false,
   });
 
-  run(() => {
+  $effect(() => {
     if (shapes.length !== collapsedSections.obstacles.length) {
       collapsedSections.obstacles = shapes.map(() => true);
     }

--- a/src/lib/components/tabs/PathTab.svelte
+++ b/src/lib/components/tabs/PathTab.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import type {
     Point,
@@ -859,7 +859,7 @@
       ? lines.map((l) => l.id).filter((id): id is string => id != null)
       : [],
   );
-  run(() => {
+  $effect(() => {
     if (lines && sequence && !repairedSequenceOnce) {
       ensureSequenceConsistency();
       repairedSequenceOnce = true;
@@ -879,7 +879,7 @@
     debugSequenceIds.filter((id) => !debugLinesIds.includes(id)) as string[],
   );
   // Reactive statements to update UI state when lines change
-  run(() => {
+  $effect(() => {
     if (lines.length !== collapsedSections.lines.length) {
       collapsedEventMarkers = lines.map(() => false);
       const wasAllCollapsed =
@@ -894,7 +894,7 @@
       };
     }
   });
-  run(() => {
+  $effect(() => {
     if ($toggleCollapseAllTrigger !== _lastToggleCollapse) {
       _lastToggleCollapse = $toggleCollapseAllTrigger;
       toggleCollapseAll();

--- a/src/lib/components/tabs/TableTab.svelte
+++ b/src/lib/components/tabs/TableTab.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { run } from "svelte/legacy";
+
 
   import type {
     Point,
@@ -35,7 +35,7 @@
   let waypointTableRef: any = $state(null);
 
   let collapsedObstacles = $state(shapes.map(() => true));
-  run(() => {
+  $effect(() => {
     if (shapes.length !== collapsedObstacles.length) {
       collapsedObstacles = shapes.map(() => true);
     }


### PR DESCRIPTION
This submission removes the deprecated `svelte/legacy` imports from the `src/lib/components/tabs/TableTab.svelte`, `src/lib/components/tabs/FieldTab.svelte`, `src/lib/components/tabs/CodeTab.svelte` and `src/lib/components/tabs/PathTab.svelte` files. Furthermore, it updates the code in these files to use the new `$effect` rune instead of the legacy `run` syntax, completing their migration to Svelte 5. All tests successfully run.

---
*PR created automatically by Jules for task [664141640468225973](https://jules.google.com/task/664141640468225973) started by @Mallen220*