### PR TITLE
fix: prevent element shortcuts from triggering when input is focused

### DIFF
--- a/src/lib/components/shortcuts/elements.ts
+++ b/src/lib/components/shortcuts/elements.ts
@@ -10,9 +10,10 @@ import { actionRegistry } from "../../actionRegistry";
 import type { Line, SequenceItem } from "../../../types/index";
 import random from "lodash/random";
 import { getRandomColor } from "../../../utils";
-import { getSelectedSequenceIndex } from "./utils";
+import { getSelectedSequenceIndex, isUIElementFocused } from "./utils";
 
 export function addNewLine(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const newLine: Line = {
     id: `line-${Math.random().toString(36).slice(2)}`,
     name: "",
@@ -50,6 +51,7 @@ export function addNewLine(recordChange: (action?: string) => void) {
 }
 
 export function addWait(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const wait: SequenceItem = {
     kind: "wait",
     id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
@@ -75,6 +77,7 @@ export function addWait(recordChange: (action?: string) => void) {
 }
 
 export function addRotate(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const rotate: SequenceItem = {
     kind: "rotate",
     id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
@@ -100,6 +103,7 @@ export function addRotate(recordChange: (action?: string) => void) {
 }
 
 export function addEventMarker(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const selPoint = get(selectedPointId);
   const sequence = get(sequenceStore);
 
@@ -180,6 +184,7 @@ export function addEventMarker(recordChange: (action?: string) => void) {
 }
 
 export function addControlPoint(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const lines = get(linesStore);
   if (lines.length === 0) return;
   const targetId = get(selectedLineId) || lines[lines.length - 1].id;
@@ -205,6 +210,7 @@ export function addControlPoint(recordChange: (action?: string) => void) {
 }
 
 export function removeControlPoint(recordChange: (action?: string) => void) {
+  if (isUIElementFocused()) return;
   const lines = get(linesStore);
   if (lines.length > 0) {
     const targetId = get(selectedLineId) || lines[lines.length - 1].id;

--- a/src/tests/lib/components/shortcuts/elements.test.ts
+++ b/src/tests/lib/components/shortcuts/elements.test.ts
@@ -13,6 +13,7 @@ import { selectedLineId, selectedPointId } from "../../../../stores";
 
 vi.mock("../../../../lib/components/shortcuts/utils", () => ({
   getSelectedSequenceIndex: vi.fn(() => null),
+  isUIElementFocused: vi.fn(() => false),
 }));
 
 describe("elements", () => {


### PR DESCRIPTION
Added `if (isUIElementFocused()) return;` to all manipulation functions in `src/lib/components/shortcuts/elements.ts` and mocked it in the tests to prevent accidental global shortcut triggers when typing in inputs.

---
*PR created automatically by Jules for task [9045635325606949914](https://jules.google.com/task/9045635325606949914) started by @Mallen220*