### PR TITLE
🧪 [Test] Add error path test for javaImporter

### DIFF
--- a/src/tests/javaImporterError.test.ts
+++ b/src/tests/javaImporterError.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import { importJavaProject } from "../utils/javaImporter";
+
+describe("javaImporter error path", () => {
+  it("returns fallback empty data on invalid java code", () => {
+    // Mock console.error to keep test output clean
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const invalidJavaCode = `
+      public class InvalidClass {
+        this is not valid java
+    `;
+    const data = importJavaProject(invalidJavaCode);
+
+    expect(data.startPoint).toEqual({ x: 0, y: 0, heading: "linear", startDeg: 0, endDeg: 0 });
+    expect(data.lines).toEqual([]);
+    expect(data.sequence).toEqual([]);
+    expect(data.shapes).toEqual([]);
+
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to parse Java code:", expect.any(Error));
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
🎯 **What:** Added a missing error path test for the `importJavaProject` function located in `src/utils/javaImporter.ts`.
📊 **Coverage:** Specifically covers the scenario where the provided Java code contains invalid syntax and fails to parse, triggering the `catch` block.
✨ **Result:** Increased test coverage by ensuring the function successfully catches syntax errors and gracefully returns the expected fallback, empty `TurtleData` structure without breaking. Suppressed console logs in the test using a Vitest spy to maintain clean output.

---
*PR created automatically by Jules for task [8830001726949833565](https://jules.google.com/task/8830001726949833565) started by @Mallen220*