### PR TITLE
Migrate CustomFieldWizard to Svelte 5 event pattern

### DIFF
--- a/src/lib/components/settings/CustomFieldWizard.svelte
+++ b/src/lib/components/settings/CustomFieldWizard.svelte
@@ -1,6 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { fade, fly } from "svelte/transition";
   import { cubicInOut } from "svelte/easing";
   import type { CustomFieldConfig } from "../../../types";
@@ -9,12 +8,12 @@
   interface Props {
     isOpen?: boolean;
     currentConfig?: CustomFieldConfig | undefined;
+    onclose?: () => void;
+    onsave?: (config: CustomFieldConfig) => void;
   }
 
-  let { isOpen = $bindable(false), currentConfig = undefined }: Props =
+  let { isOpen = $bindable(false), currentConfig = undefined, onclose, onsave }: Props =
     $props();
-
-  const dispatch = createEventDispatcher();
 
   let step = $state(1); // 1: Upload, 2: Calibrate Field Bounds, 3: Review
   let imageData: string | null = $state(null);
@@ -52,7 +51,7 @@
   });
 
   function handleClose() {
-    dispatch("close");
+    onclose?.();
   }
 
   function handleImageUpload(e: Event) {
@@ -135,8 +134,8 @@
   function handleSave() {
     const config = calculateConfig();
     if (config) {
-      dispatch("save", config);
-      dispatch("close");
+      onsave?.(config);
+      onclose?.();
     }
   }
 

--- a/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/InterfaceSettingsTab.svelte
@@ -56,8 +56,7 @@
     fieldPan.set({ x: 0, y: 0 });
   }
 
-  function handleCustomFieldSave(e: CustomEvent<CustomFieldConfig>) {
-    const newConfig = e.detail;
+  function handleCustomFieldSave(newConfig: CustomFieldConfig) {
     if (!settings.customMaps) settings.customMaps = [];
 
     const index = settings.customMaps.findIndex((m) => m.id === newConfig.id);
@@ -466,6 +465,6 @@
 <CustomFieldWizard
   bind:isOpen={isCustomFieldWizardOpen}
   currentConfig={editingCustomConfig}
-  on:save={handleCustomFieldSave}
-  on:close={() => (isCustomFieldWizardOpen = false)}
+  onsave={handleCustomFieldSave}
+  onclose={() => (isCustomFieldWizardOpen = false)}
 />


### PR DESCRIPTION
Replaces Svelte 4 `createEventDispatcher` with modern Svelte 5 callback properties (`onclose`, `onsave`) for better type safety and performance in `CustomFieldWizard.svelte` and `InterfaceSettingsTab.svelte`.

---
*PR created automatically by Jules for task [17801419866781582847](https://jules.google.com/task/17801419866781582847) started by @Mallen220*