### PR TITLE
fix: whitelist zoom and pan keybinds when inputs are focused

### DIFF
--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(globalThis, { key: "Escape" });
+    await fireEvent.keyDown(window, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -43,7 +43,16 @@ export function shouldBlockShortcut(
     actionId === "undo" ||
     actionId === "redo" ||
     actionId === "open-settings" ||
-    actionId === "toggle-sidebar"
+    actionId === "toggle-sidebar" ||
+    actionId === "zoom-in" ||
+    actionId === "zoom-out" ||
+    actionId === "zoom-reset" ||
+    actionId === "pan-view-up" ||
+    actionId === "pan-view-down" ||
+    actionId === "pan-view-left" ||
+    actionId === "pan-view-right" ||
+    actionId === "pan-start" ||
+    actionId === "pan-end"
   )
     return false;
   if (e.key === "Escape") return false;

--- a/src/tests/lib/components/shortcuts/utils.test.ts
+++ b/src/tests/lib/components/shortcuts/utils.test.ts
@@ -66,6 +66,21 @@ describe("shortcuts utils", () => {
         false,
       );
       expect(!!shouldBlockShortcut({} as KeyboardEvent, "undo")).toBe(false);
+
+      const viewActions = [
+        "zoom-in",
+        "zoom-out",
+        "zoom-reset",
+        "pan-view-up",
+        "pan-view-down",
+        "pan-view-left",
+        "pan-view-right",
+        "pan-start",
+        "pan-end",
+      ];
+      viewActions.forEach((action) => {
+        expect(!!shouldBlockShortcut({} as KeyboardEvent, action)).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes an issue where zoom and pan keybindings were inappropriately blocked while an input or text area element was focused. 

This enhances the overall accessibility and user experience by ensuring viewport navigation commands consistently work. Additionally fixes a minor type check error in the tests related to `globalThis` usage with JSDom.

---
*PR created automatically by Jules for task [378955522357366475](https://jules.google.com/task/378955522357366475) started by @Mallen220*