### PR TITLE
Migrate SetupDialog.svelte to Svelte 5

### DIFF
--- a/review_reply.md
+++ b/review_reply.md
@@ -1,0 +1,1 @@
+I checked usages of `SetupDialog` in `src/App.svelte` and it is called as `<SetupDialog bind:show={setupMode} />` on line 1783. There is no `on:setupComplete` usage in the codebase. As such, I believe the change is complete.

--- a/src/lib/components/dialogs/SetupDialog.svelte
+++ b/src/lib/components/dialogs/SetupDialog.svelte
@@ -1,17 +1,14 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-
   import { saveAutoPathsDirectory } from "../../../utils/directorySettings";
   import { RocketIcon, FolderIcon } from "../icons";
 
   interface Props {
     show?: boolean;
+    onsetupComplete?: () => void;
   }
 
-  let { show = $bindable(false) }: Props = $props();
-
-  const dispatch = createEventDispatcher();
+  let { show = $bindable(false), onsetupComplete }: Props = $props();
 
   async function selectDirectory() {
     const electronAPI = (globalThis as any).electronAPI;
@@ -21,7 +18,7 @@
         if (selected) {
           await saveAutoPathsDirectory(selected);
           show = false;
-          dispatch("setupComplete");
+          onsetupComplete?.();
         }
       } catch (err) {}
     }


### PR DESCRIPTION
Migrate Svelte 4 logic in `SetupDialog.svelte` to Svelte 5 logic using callback props instead of `createEventDispatcher`. Checked that there are no usages of `on:setupComplete` that would have broken. Checked unit tests and overall types check out.

---
*PR created automatically by Jules for task [15936523631604516521](https://jules.google.com/task/15936523631604516521) started by @Mallen220*