### PR TITLE
Migrate PlaybackControls to Svelte 5 callback props

### DIFF
--- a/src/lib/ControlTab.svelte
+++ b/src/lib/ControlTab.svelte
@@ -181,8 +181,8 @@
     }
   }
 
-  function handleMarkerChange(e: CustomEvent) {
-    const { id, percent } = e.detail;
+  function handleMarkerChange(detail: { id: string; percent: number }) {
+    const { id, percent } = detail;
     if (!timePrediction || timePrediction.totalTime <= 0) return;
 
     const globalTime = (percent / 100) * timePrediction.totalTime;
@@ -326,8 +326,8 @@
     }
   }
 
-  function handleMarkerAction(e: CustomEvent) {
-    const { id, action } = e.detail;
+  function handleMarkerAction(detail: { id: string; action: string }) {
+    const { id, action } = detail;
     if (action === "delete") {
       let found = false;
 
@@ -714,8 +714,8 @@
       {totalSeconds}
       {settings}
       {splitPath}
-      on:markerChange={handleMarkerChange}
-      on:markerAction={handleMarkerAction}
+      onmarkerChange={handleMarkerChange}
+      onmarkerAction={handleMarkerAction}
     />
   </div>
 </div>

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -5,7 +5,7 @@
   import { cubicInOut } from "svelte/easing";
   import { menuNavigation } from "../actions/menuNavigation";
   import { formatTime, getShortcutFromSettings } from "../../utils";
-  import { createEventDispatcher, onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { loopRangeActiveStore, loopRangeStore } from "../../lib/projectStore";
   import ContextMenu from "./tools/ContextMenu.svelte";
   import {
@@ -45,6 +45,8 @@
     totalSeconds?: number;
     settings: Settings | undefined;
     splitPath?: () => void;
+    onmarkerChange?: (data: { id: string; percent: number }) => void;
+    onmarkerAction?: (data: { id: string; action: string }) => void;
   }
 
   let {
@@ -60,9 +62,9 @@
     totalSeconds = 0,
     settings,
     splitPath = () => {},
+    onmarkerChange,
+    onmarkerAction,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher();
 
   // Speed dropdown state & helpers
   let showSpeedMenu = $state(false);
@@ -316,7 +318,7 @@
     if (draggingMarkerIndex !== null) {
       // Commit change
       if (draggingMarkerId) {
-        dispatch("markerChange", {
+        onmarkerChange?.({
           id: draggingMarkerId,
           percent: draggingMarkerPercent,
         });
@@ -346,7 +348,7 @@
 
   function handleContextMenuAction(action: string) {
     if (contextMenuTargetId) {
-      dispatch("markerAction", { id: contextMenuTargetId, action });
+      onmarkerAction?.({ id: contextMenuTargetId, action });
     }
     showContextMenu = false;
   }


### PR DESCRIPTION
This commit migrates the `PlaybackControls` component from Svelte 4's `createEventDispatcher` to Svelte 5's callback props (`onmarkerChange` and `onmarkerAction`). It also updates the parent `ControlTab.svelte` component to pass these events down as props. Tests were confirmed to be using the modern testing library format and still pass cleanly.

---
*PR created automatically by Jules for task [11802479864025796916](https://jules.google.com/task/11802479864025796916) started by @Mallen220*