### PR TITLE
fix(shortcuts): add id to focusRequest payloads for x/y/heading keybinds

### DIFF
--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -524,10 +524,24 @@
         (document.activeElement as HTMLElement).blur();
       }
     },
-    focusX: () => focusRequest.set({ field: "x", timestamp: Date.now(), id: $selectedPointId || undefined }),
-    focusY: () => focusRequest.set({ field: "y", timestamp: Date.now(), id: $selectedPointId || undefined }),
+    focusX: () =>
+      focusRequest.set({
+        field: "x",
+        timestamp: Date.now(),
+        id: $selectedPointId || undefined,
+      }),
+    focusY: () =>
+      focusRequest.set({
+        field: "y",
+        timestamp: Date.now(),
+        id: $selectedPointId || undefined,
+      }),
     focusHeading: () =>
-      focusRequest.set({ field: "heading", timestamp: Date.now(), id: $selectedPointId || undefined }),
+      focusRequest.set({
+        field: "heading",
+        timestamp: Date.now(),
+        id: $selectedPointId || undefined,
+      }),
     togglePlay: () => {
       if (playing) pause();
       else play();

--- a/src/lib/components/KeyboardShortcuts.svelte
+++ b/src/lib/components/KeyboardShortcuts.svelte
@@ -524,10 +524,10 @@
         (document.activeElement as HTMLElement).blur();
       }
     },
-    focusX: () => focusRequest.set({ field: "x", timestamp: Date.now() }),
-    focusY: () => focusRequest.set({ field: "y", timestamp: Date.now() }),
+    focusX: () => focusRequest.set({ field: "x", timestamp: Date.now(), id: $selectedPointId || undefined }),
+    focusY: () => focusRequest.set({ field: "y", timestamp: Date.now(), id: $selectedPointId || undefined }),
     focusHeading: () =>
-      focusRequest.set({ field: "heading", timestamp: Date.now() }),
+      focusRequest.set({ field: "heading", timestamp: Date.now(), id: $selectedPointId || undefined }),
     togglePlay: () => {
       if (playing) pause();
       else play();


### PR DESCRIPTION
Updates the `focusX`, `focusY`, and `focusHeading` shortcuts to explicitly set the `id` of the `focusRequest` so that the targeted inputs successfully match the request and apply focus correctly.

Fixes an issue where pressing "x", "y", or "h" to focus coordinate fields might fail to correctly apply focus to the selected item.

---
*PR created automatically by Jules for task [7926617259315590233](https://jules.google.com/task/7926617259315590233) started by @Mallen220*