### PR TITLE
fix: allow show-help shortcut when input is focused

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -32,6 +32,7 @@ export function shouldBlockShortcut(
   // Whitelist specific actions that should work even when input is focused
   if (
     actionId === "toggle-command-palette" ||
+    actionId === "show-help" ||
     actionId === "cycle-tabs-next" ||
     actionId === "cycle-tabs-prev" ||
     actionId === "select-code-tab" ||


### PR DESCRIPTION
This PR fixes an issue where the "show-help" keyboard shortcut (typically `Shift+/` or `?`) would not trigger if an input element was focused. By whitelisting the "show-help" action ID in the `shouldBlockShortcut` utility, the keyboard shortcuts dialog can now be opened seamlessly at any time.

---
*PR created automatically by Jules for task [5269226439701702721](https://jules.google.com/task/5269226439701702721) started by @Mallen220*