### PR TITLE
feat(shortcuts): expand keybinding whitelist for better UX

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -53,7 +53,9 @@ export function shouldBlockShortcut(
     actionId === "pan-view-left" ||
     actionId === "pan-view-right" ||
     actionId === "pan-start" ||
-    actionId === "pan-end"
+    actionId === "pan-end" ||
+    actionId === "toggle-lock-field-view" ||
+    actionId === "toggle-continuous-validation"
   )
     return false;
   if (e.key === "Escape") return false;


### PR DESCRIPTION
This PR adds 'toggle-lock-field-view' and 'toggle-continuous-validation' to the whitelist of actionIDs in `shouldBlockShortcut`. 

This addresses the issue asking for better keybind support by enabling users to trigger these useful features even when an input field is focused.

---
*PR created automatically by Jules for task [10507160456858355196](https://jules.google.com/task/10507160456858355196) started by @Mallen220*