### PR TITLE
fix: add aria-labels to close buttons

### DIFF
--- a/src/lib/components/dialogs/StrategySheetPreview.svelte
+++ b/src/lib/components/dialogs/StrategySheetPreview.svelte
@@ -531,6 +531,7 @@
           </button>
           <button
             onclick={handleClose}
+            aria-label="Close"
             class="p-2 rounded-lg text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors"
           >
             <CloseIcon className="size-5" />

--- a/src/lib/components/settings/CustomFieldWizard.svelte
+++ b/src/lib/components/settings/CustomFieldWizard.svelte
@@ -257,6 +257,7 @@
         </h2>
         <button
           onclick={handleClose}
+          aria-label="Close"
           class="text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
         >
           <CloseIcon className="h-6 w-6" />

--- a/src/lib/components/whats-new/WhatsNewDialog.svelte
+++ b/src/lib/components/whats-new/WhatsNewDialog.svelte
@@ -210,6 +210,7 @@
           <!-- Mobile Close -->
           <button
             onclick={close}
+            aria-label="Close"
             class="md:hidden p-2 -mr-2 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400"
           >
             <CloseIcon className="h-5 w-5" />
@@ -300,6 +301,7 @@
           <!-- Desktop Close -->
           <button
             onclick={close}
+            aria-label="Close"
             class="hidden md:block p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-300 transition-colors rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-800"
           >
             <CloseIcon className="h-5 w-5" />


### PR DESCRIPTION
Adds aria-labels to several icon-only buttons across dialogs to improve accessibility for screen readers.

Fixes an issue where `StrategySheetPreview`, `CustomFieldWizard`, and `WhatsNewDialog` contained icon-only buttons without an `aria-label`, causing them to be read as empty buttons by screen readers.

---
*PR created automatically by Jules for task [171114277928322971](https://jules.google.com/task/171114277928322971) started by @Mallen220*