### PR TITLE
feat: add keyboard shortcuts button to sidebar

### DIFF
--- a/src/config/sidebarItems.ts
+++ b/src/config/sidebarItems.ts
@@ -35,6 +35,7 @@ import {
   PhotoIcon,
   ExportGifIcon,
   SearchIcon,
+  KeyboardIcon,
   RobotPlaceholderIcon,
 } from "../lib/components/icons";
 
@@ -56,6 +57,13 @@ export const SIDEBAR_ITEMS: SidebarItemConfig[] = [
     type: "system",
     shortcutKey: "toggle-file-manager",
     iconComponent: FolderIcon,
+  },
+  {
+    id: "keyboardShortcuts",
+    label: "Keyboard Shortcuts",
+    type: "system",
+    shortcutKey: "show-help",
+    iconComponent: KeyboardIcon,
   },
   {
     id: "commandPalette",

--- a/src/lib/components/LeftSidebar.svelte
+++ b/src/lib/components/LeftSidebar.svelte
@@ -25,6 +25,7 @@
     showFeedbackDialog,
     showSettings,
     showHistory,
+    showShortcuts,
     isDrawingMode,
     showRuler,
     showProtractor,
@@ -472,6 +473,45 @@
             </button>
           </div>
 
+                {:else if item.id === "keyboardShortcuts"}
+          <!-- Keyboard Shortcuts -->
+          <div
+            draggable={sidebarExpanded}
+            ondragstart={(e) => handleDragStart(e, idx)}
+            ondragover={(e) => handleDragOver(e, idx)}
+            ondragleave={() => handleDragLeave(idx)}
+            ondrop={(e) => handleDrop(e, idx)}
+            ondragend={handleDragEnd}
+            role="listitem"
+            class="w-full flex justify-center transition-all {dragOverIndex ===
+              idx && dragSourceIndex !== idx
+              ? 'ring-2 ring-blue-400 dark:ring-blue-500 bg-blue-50 dark:bg-blue-900/20'
+              : ''} {dragSourceIndex === idx ? 'opacity-30 scale-95' : ''}"
+          >
+            <button
+              title={item.shortcutKey && settings.keyBindings ? `${item.label} (${getShortcutFromSettings(settings, item.shortcutKey)})` : item.label}
+              aria-label={item.label}
+              onclick={() => showShortcuts.set(true)}
+              class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
+                ? 'w-[calc(100%-1.1rem)] px-3'
+                : 'justify-center'} text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800"
+            >
+              <div
+                class="sidebar-icon flex-none flex items-center justify-center"
+              >
+                {#if item.iconComponent}
+                  <item.iconComponent
+                    className="sidebar-icon-small flex-none"
+                  />
+                {/if}
+              </div>
+              {#if sidebarExpanded}
+                <span class="ml-3 text-sm font-medium truncate"
+                  >{item.label}</span
+                >
+              {/if}
+            </button>
+          </div>
         {:else if item.id === "commandPalette"}
           <!-- Command Palette -->
           <div

--- a/src/lib/components/icons/KeyboardIcon.svelte
+++ b/src/lib/components/icons/KeyboardIcon.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  let { className = "size-5" } = $props();
+</script>
+
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  fill="none"
+  viewBox="0 0 24 24"
+  stroke-width="1.5"
+  stroke="currentColor"
+  class={className}
+>
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M6.75 7.5h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm-9 3h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm-9 3h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm3 0h.75v.75h-.75v-.75zm-6 3h10.5v.75h-10.5v-.75z"
+  />
+  <path
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    d="M3 5.25C3 4.007 4.007 3 5.25 3h13.5C19.993 3 21 4.007 21 5.25v13.5c0 1.243-1.007 2.25-2.25 2.25H5.25C4.007 21 3 19.993 3 18.75V5.25z"
+  />
+</svg>

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -109,3 +109,4 @@ export { default as RobotPlaceholderIcon } from "./RobotPlaceholderIcon.svelte";
 export { default as CriticalIcon } from "./CriticalIcon.svelte";
 export { default as DisabledIcon } from "./DisabledIcon.svelte";
 export { default as EllipsisVerticalIcon } from "./EllipsisVerticalIcon.svelte";
+export { default as KeyboardIcon } from "./KeyboardIcon.svelte";


### PR DESCRIPTION
Added a dedicated "Keyboard Shortcuts" button to the main LeftSidebar navigation to improve accessibility and discoverability of keybindings, directly launching the shortcuts dialog.

---
*PR created automatically by Jules for task [10145494832339668970](https://jules.google.com/task/10145494832339668970) started by @Mallen220*