### PR TITLE
Improve Fine-Tuning Keybind Support

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -55,7 +55,11 @@ export function shouldBlockShortcut(
     actionId === "pan-start" ||
     actionId === "pan-end" ||
     actionId === "toggle-lock-field-view" ||
-    actionId === "toggle-continuous-validation"
+    actionId === "toggle-continuous-validation" ||
+    actionId === "increase-val" ||
+    actionId === "decrease-val" ||
+    actionId === "increase-val-small" ||
+    actionId === "decrease-val-small"
   )
     return false;
   if (e.key === "Escape") return false;


### PR DESCRIPTION
This submission improves keybinding support by adding the fine-tuning increment/decrement shortcuts to the shortcut whitelist. This allows users to press shift and plus/minus keys while focused in an input field (like duration or rotation inputs) to safely increment or decrement the value without the shortcut manager dropping the event.

---
*PR created automatically by Jules for task [10559805234240151888](https://jules.google.com/task/10559805234240151888) started by @Mallen220*