### PR TITLE
Migrate FileManagerToolbar to Svelte 5 callback props

### DIFF
--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -1231,10 +1231,10 @@
         {searchQuery}
         {sortMode}
         {viewMode}
-        on:search={(e) => (searchQuery = e.detail)}
-        on:sort-change={(e) => (sortMode = e.detail)}
-        on:view-change={(e) => {
-          viewMode = e.detail;
+        onsearch={(val) => (searchQuery = val)}
+        onsortchange={(val) => (sortMode = val)}
+        onviewchange={(val) => {
+          viewMode = val;
           // If switching to list/grid view, retry any previously failed previews so icons repopulate reliably
           if (viewMode === "list") {
             fileList?.refreshAllFailed?.();

--- a/src/lib/components/filemanager/FileManagerToolbar.svelte
+++ b/src/lib/components/filemanager/FileManagerToolbar.svelte
@@ -1,7 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <!-- src/lib/components/filemanager/FileManagerToolbar.svelte -->
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import {
     SearchIcon,
     SortNameIcon,
@@ -14,24 +13,24 @@
     searchQuery?: string;
     sortMode?: "name" | "date";
     viewMode?: "list" | "grid";
+    onsortchange?: (mode: "name" | "date") => void;
+    onviewchange?: (mode: "list" | "grid") => void;
+    onsearch?: (query: string) => void;
   }
 
   let {
     searchQuery = $bindable(""),
     sortMode = "name",
     viewMode = "list",
+    onsortchange,
+    onviewchange,
+    onsearch,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    "sort-change": "name" | "date";
-    "view-change": "list" | "grid";
-    search: string;
-  }>();
 
   function handleSearch(e: Event) {
     const target = e.target as HTMLInputElement;
     searchQuery = target.value;
-    dispatch("search", searchQuery);
+    onsearch?.(searchQuery);
   }
 </script>
 
@@ -59,7 +58,7 @@
     <!-- Sort Toggle -->
     <button
       onclick={() =>
-        dispatch("sort-change", sortMode === "name" ? "date" : "name")}
+        onsortchange?.(sortMode === "name" ? "date" : "name")}
       class="p-1.5 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       title={`Sort by ${sortMode === "name" ? "Date" : "Name"}`}
       aria-label={`Sort by ${sortMode === "name" ? "Date" : "Name"}`}
@@ -74,7 +73,7 @@
     <!-- View Toggle -->
     <button
       onclick={() =>
-        dispatch("view-change", viewMode === "list" ? "grid" : "list")}
+        onviewchange?.(viewMode === "list" ? "grid" : "list")}
       class="p-1.5 text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-200 rounded hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
       title={`Switch to ${viewMode === "list" ? "Grid" : "List"} View`}
       aria-label={`Switch to ${viewMode === "list" ? "Grid" : "List"} View`}


### PR DESCRIPTION
Refactored `FileManagerToolbar.svelte` from Svelte 4 `createEventDispatcher` to Svelte 5 standard callback props.

Changes made:
- Added `onsortchange`, `onviewchange`, and `onsearch` properties to the `Props` interface of `FileManagerToolbar.svelte`
- Replaced custom event dispatch calls in `FileManagerToolbar` with direct callback executions
- Updated `FileManager.svelte` to bind the new callback properties and removed the `on:` event listeners
- Ran `npm run check` and `npm run test` successfully.

This fully aligns the component with the new Svelte 5 paradigms.

---
*PR created automatically by Jules for task [56946129136235626](https://jules.google.com/task/56946129136235626) started by @Mallen220*