### PR TITLE
fix(shortcuts): whitelist movement and decrease value keybinds

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -59,7 +59,13 @@ export function shouldBlockShortcut(
     actionId === "increase-val" ||
     actionId === "decrease-val" ||
     actionId === "increase-val-small" ||
-    actionId === "decrease-val-small"
+    actionId === "decrease-val-small" ||
+    actionId === "move-point-up" ||
+    actionId === "move-point-down" ||
+    actionId === "move-point-left" ||
+    actionId === "move-point-right" ||
+    actionId === "move-item-up" ||
+    actionId === "move-item-down"
   )
     return false;
   if (e.key === "Escape") return false;


### PR DESCRIPTION
Whitelisted the remaining sequence modifications and movement shortcuts from being blocked by input focus.

---
*PR created automatically by Jules for task [6887525179044881530](https://jules.google.com/task/6887525179044881530) started by @Mallen220*