### PR TITLE
Fix shortcut whitelist to prevent input interaction hijacking

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -56,17 +56,7 @@ export function shouldBlockShortcut(
     actionId === "pan-start" ||
     actionId === "pan-end" ||
     actionId === "toggle-lock-field-view" ||
-    actionId === "toggle-continuous-validation" ||
-    actionId === "increase-val" ||
-    actionId === "decrease-val" ||
-    actionId === "increase-val-small" ||
-    actionId === "decrease-val-small" ||
-    actionId === "move-point-up" ||
-    actionId === "move-point-down" ||
-    actionId === "move-point-left" ||
-    actionId === "move-point-right" ||
-    actionId === "move-item-up" ||
-    actionId === "move-item-down"
+    actionId === "toggle-continuous-validation"
   )
     return false;
   if (e.key === "Escape") return false;


### PR DESCRIPTION
Removes arrow key and typing character shortcut bindings (like `increase-val`, `move-item-up`) from the shortcut blocking whitelist. This prevents global keybindings from incorrectly triggering and preventing default cursor/typing behavior when a text input or textarea is actively focused.

---
*PR created automatically by Jules for task [9221501826551407931](https://jules.google.com/task/9221501826551407931) started by @Mallen220*