### PR TITLE
Migrate Svelte 4 event dispatchers to Svelte 5 callback props

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1724,7 +1724,7 @@
     robotStateFunction={(p) =>
       calculateRobotState(p, timePrediction.timeline, lines, startPoint, x, y)}
     {electronAPI}
-    on:close={() => showExportGif.set(false)}
+    onclose={() => showExportGif.set(false)}
   />
 {/if}
 
@@ -1750,7 +1750,7 @@
       ).heading,
     }}
     {electronAPI}
-    on:close={() => showExportImage.set(false)}
+    onclose={() => showExportImage.set(false)}
   />
 {/if}
 
@@ -1786,7 +1786,7 @@
   whatsNewOpen={$showWhatsNew}
   setupDialogOpen={setupMode}
   {isLoaded}
-  on:tutorialComplete={() => showWhatsNew.set(true)}
+  ontutorialComplete={() => showWhatsNew.set(true)}
 />
 
 <SaveNameDialog

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -410,8 +410,7 @@
   }
 
   // Handle directory change (manual input)
-  async function changeDirectoryManual(e: CustomEvent<string>) {
-    const newDir = e.detail;
+  async function changeDirectoryManual(newDir: string) {
     if (!newDir) return;
 
     try {
@@ -540,9 +539,9 @@
 
   // File Operations
   async function handleMoveFile(
-    e: CustomEvent<{ sourceFile: FileInfo; targetDir: FileInfo }>,
+    data: { sourceFile: FileInfo; targetDir: FileInfo },
   ) {
-    const { sourceFile, targetDir } = e.detail;
+    const { sourceFile, targetDir } = data;
     if (!targetDir.isDirectory) return;
     if (sourceFile.path === targetDir.path) return;
     if (sourceFile.name === "..") return; // cannot move the .. directory itself
@@ -1026,9 +1025,8 @@
   }
 
   // Event handlers for child components
-  function handleMenuAction(e: any) {
-    // If called from template with detail extracted or raw event
-    const { action, file } = e.detail || e;
+  function handleMenuAction(data: { action: string; file: FileInfo }) {
+    const { action, file } = data;
     switch (action) {
       case "open":
         handleOpen(file);
@@ -1251,9 +1249,9 @@
     <FileManagerBreadcrumbs
       currentPath={currentDirectory}
       isAtBase={currentDirectory === baseDirectory}
-      on:change-dir={changeDirectoryManual}
-      on:change-dir-dialog={changeDirectoryDialog}
-      on:go-up={goUpDirectory}
+      onchangeDir={changeDirectoryManual}
+      onchangeDirDialog={changeDirectoryDialog}
+      ongoUp={goUpDirectory}
     />
 
     <!-- Error Display -->
@@ -1464,14 +1462,14 @@
           {sortMode}
           fieldImage={settings.fieldMap}
           {renamingFile}
-          on:select={(e) => (selectedFile = e.detail)}
-          on:open={(e) => handleOpen(e.detail)}
-          on:rename-start={(e) => (renamingFile = e.detail)}
-          on:rename-save={(e) =>
-            renamingFile && renameFile(renamingFile, e.detail)}
-          on:rename-cancel={() => (renamingFile = null)}
-          on:menu-action={handleMenuAction}
-          on:move-file={handleMoveFile}
+          onselect={(file) => (selectedFile = file)}
+          onopen={(file) => handleOpen(file)}
+          onrenameStart={(file) => (renamingFile = file)}
+          onrenameSave={(name) =>
+            renamingFile && renameFile(renamingFile, name)}
+          onrenameCancel={() => (renamingFile = null)}
+          onmenuAction={handleMenuAction}
+          onmoveFile={handleMoveFile}
         />
       {:else}
         <FileGrid
@@ -1482,14 +1480,14 @@
           fieldImage={settings.fieldMap}
           showGitStatus={settings.gitIntegration}
           {renamingFile}
-          on:select={(e) => (selectedFile = e.detail)}
-          on:open={(e) => handleOpen(e.detail)}
-          on:rename-start={(e) => (renamingFile = e.detail)}
-          on:rename-save={(e) =>
-            renamingFile && renameFile(renamingFile, e.detail)}
-          on:rename-cancel={() => (renamingFile = null)}
-          on:menu-action={handleMenuAction}
-          on:move-file={handleMoveFile}
+          onselect={(file) => (selectedFile = file)}
+          onopen={(file) => handleOpen(file)}
+          onrenameStart={(file) => (renamingFile = file)}
+          onrenameSave={(name) =>
+            renamingFile && renameFile(renamingFile, name)}
+          onrenameCancel={() => (renamingFile = null)}
+          onmenuAction={handleMenuAction}
+          onmoveFile={handleMoveFile}
         />
       {/if}
     </div>

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -2656,7 +2656,7 @@
       x={contextMenuX}
       y={contextMenuY}
       items={contextMenuItems}
-      on:close={() => (showContextMenu = false)}
+      onclose={() => (showContextMenu = false)}
     />
   {/if}
 

--- a/src/lib/components/OnboardingTutorial.svelte
+++ b/src/lib/components/OnboardingTutorial.svelte
@@ -1,6 +1,5 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
   import { driver } from "driver.js";
   import "driver.js/dist/driver.css";
   import { startTutorial } from "../../stores";
@@ -10,15 +9,15 @@
     whatsNewOpen?: boolean;
     setupDialogOpen?: boolean;
     isLoaded?: boolean;
+    ontutorialComplete?: () => void;
   }
 
   let {
     whatsNewOpen = false,
     setupDialogOpen = false,
     isLoaded = false,
+    ontutorialComplete,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher();
 
   // Dev flag to force start tutorial
   const FORCE_START_DEV = false;
@@ -136,7 +135,7 @@
       // If this was the initial first-run tutorial, trigger the "What's New" / Docs
       if (isFirstRun) {
         isFirstRun = false;
-        dispatch("tutorialComplete");
+        ontutorialComplete?.();
       }
     },
   });

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -365,8 +365,8 @@
         danger: true,
       },
     ]}
-    on:close={() => (showContextMenu = false)}
-    on:action={(e) => handleContextMenuAction(e.detail)}
+    onclose={() => (showContextMenu = false)}
+    onaction={(action) => handleContextMenuAction(action)}
   />
 {/if}
 

--- a/src/lib/components/WaypointTable.svelte
+++ b/src/lib/components/WaypointTable.svelte
@@ -1306,7 +1306,7 @@
     x={contextMenuX}
     y={contextMenuY}
     items={contextMenuItems}
-    on:close={() => (contextMenuOpen = false)}
+    onclose={() => (contextMenuOpen = false)}
   />
 {/if}
 

--- a/src/lib/components/common/SearchableDropdown.svelte
+++ b/src/lib/components/common/SearchableDropdown.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher, tick } from "svelte";
+  import { tick } from "svelte";
   import { slide } from "svelte/transition";
 
   interface Props {
@@ -18,8 +18,6 @@
     disabled = false,
     onchange,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher();
 
   let isOpen = $state(false);
   let inputElement: HTMLInputElement | undefined = $state();
@@ -43,7 +41,6 @@
   function handleInput(e: Event) {
     value = (e.target as HTMLInputElement).value;
     isOpen = true;
-    dispatch("change", value);
     onchange?.(value);
   }
 
@@ -62,7 +59,6 @@
     value = opt;
     isOpen = false;
     highlightedIndex = -1;
-    dispatch("change", value);
     onchange?.(value);
   }
 

--- a/src/lib/components/dialogs/ExportGifDialog.svelte
+++ b/src/lib/components/dialogs/ExportGifDialog.svelte
@@ -1,14 +1,12 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { untrack, onMount, onDestroy, createEventDispatcher } from "svelte";
+  import { untrack, onMount, onDestroy } from "svelte";
   import { scale } from "svelte/transition";
   import {
     exportPathToGif,
     exportPathToApng,
   } from "../../../utils/exportAnimation";
   import { CloseIcon, PhotoIcon } from "../icons";
-
-  const dispatch = createEventDispatcher();
 
   let format: "gif" | "apng" = $state("gif");
   let fps = $state(15);
@@ -64,7 +62,7 @@
         console.warn("Abort threw", e);
       }
 
-      dispatch("close");
+      onclose?.();
       return;
     }
 
@@ -75,7 +73,7 @@
     previewBlob = null;
     status = "idle";
     progress = 0;
-    dispatch("close");
+    onclose?.();
   }
 
   function handleCancel() {
@@ -213,6 +211,7 @@
       heading: number;
     };
     electronAPI: any;
+    onclose?: () => void;
   }
 
   let {
@@ -224,6 +223,7 @@
     robotWidthPx,
     robotStateFunction,
     electronAPI,
+    onclose,
   }: Props = $props();
 
   onMount(() => {

--- a/src/lib/components/dialogs/ExportImageDialog.svelte
+++ b/src/lib/components/dialogs/ExportImageDialog.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher, onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { get } from "svelte/store";
   import { scale } from "svelte/transition";
   import { exportPathToImage } from "../../../utils/exportAnimation";
@@ -19,6 +19,7 @@
     // D3 Scales passed as functions
     xScale?: (v: number) => number;
     yScale?: (v: number) => number;
+    onclose?: () => void;
   }
 
   let {
@@ -31,9 +32,8 @@
     electronAPI,
     xScale = (v) => v,
     yScale = (v) => v,
+    onclose,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher();
 
   let format: "png" | "jpeg" | "svg" = $state("png");
   let resolutionScale = $state(1);
@@ -62,7 +62,7 @@
     previewUrl = null;
     previewBlob = null;
     status = "idle";
-    dispatch("close");
+    onclose?.();
   }
 
   function toggleValidationVisibility(visible: boolean) {

--- a/src/lib/components/dialogs/SetupDialog.svelte
+++ b/src/lib/components/dialogs/SetupDialog.svelte
@@ -1,17 +1,14 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher } from "svelte";
-
   import { saveAutoPathsDirectory } from "../../../utils/directorySettings";
   import { RocketIcon, FolderIcon } from "../icons";
 
   interface Props {
     show?: boolean;
+    onsetupComplete?: () => void;
   }
 
-  let { show = $bindable(false) }: Props = $props();
-
-  const dispatch = createEventDispatcher();
+  let { show = $bindable(false), onsetupComplete }: Props = $props();
 
   async function selectDirectory() {
     const electronAPI = (globalThis as any).electronAPI;
@@ -21,7 +18,7 @@
         if (selected) {
           await saveAutoPathsDirectory(selected);
           show = false;
-          dispatch("setupComplete");
+          onsetupComplete?.();
         }
       } catch (err) {}
     }

--- a/src/lib/components/filemanager/FileContextMenu.svelte
+++ b/src/lib/components/filemanager/FileContextMenu.svelte
@@ -1,7 +1,7 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <!-- src/lib/components/filemanager/FileContextMenu.svelte -->
 <script lang="ts">
-  import { createEventDispatcher, onMount, tick } from "svelte";
+  import { onMount, tick } from "svelte";
   import { fade } from "svelte/transition";
   import { menuNavigation } from "../../actions/menuNavigation";
   import {
@@ -18,27 +18,17 @@
     y: number;
     fileName: string;
     isDirectory?: boolean;
+    onclose?: () => void;
+    onaction?: (action: "open" | "rename" | "delete" | "duplicate" | "mirror" | "reverse" | "save-to") => void;
   }
 
-  let { x, y, fileName, isDirectory = false }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    close: void;
-    action:
-      | "open"
-      | "rename"
-      | "delete"
-      | "duplicate"
-      | "mirror"
-      | "reverse"
-      | "save-to";
-  }>();
+  let { x, y, fileName, isDirectory = false, onclose, onaction }: Props = $props();
 
   let menuElement: HTMLDivElement | undefined = $state();
 
   function handleClickOutside(event: MouseEvent) {
     if (menuElement && !menuElement.contains(event.target as Node)) {
-      dispatch("close");
+      onclose?.();
     }
   }
 
@@ -88,7 +78,7 @@
 
 <div
   use:menuNavigation
-  onclose={() => dispatch("close")}
+  onclose={() => onclose?.()}
   bind:this={menuElement}
   class="fixed z-[1200] min-w-[160px] py-1 bg-white dark:bg-neutral-800 rounded-lg shadow-xl border border-neutral-200 dark:border-neutral-700 text-sm"
   style="top: {adjustedY}px; left: {adjustedX}px;"
@@ -103,7 +93,7 @@
   </div>
 
   <button
-    onclick={() => dispatch("action", "open")}
+    onclick={() => onaction?.("open")}
     class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
   >
     <ArrowRightIcon className="size-4" />
@@ -112,7 +102,7 @@
 
   {#if !isDirectory}
     <button
-      onclick={() => dispatch("action", "save-to")}
+      onclick={() => onaction?.("save-to")}
       class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
     >
       <ArrowDownTrayIcon className="size-4" />
@@ -122,7 +112,7 @@
   <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-1"></div>
 
   <button
-    onclick={() => dispatch("action", "rename")}
+    onclick={() => onaction?.("rename")}
     class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
   >
     <PenIcon className="size-4" strokeWidth={1.5} />
@@ -131,7 +121,7 @@
 
   {#if !isDirectory}
     <button
-      onclick={() => dispatch("action", "duplicate")}
+      onclick={() => onaction?.("duplicate")}
       class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
     >
       <DocumentIcon className="size-4" strokeWidth={1.5} />
@@ -139,7 +129,7 @@
     </button>
 
     <button
-      onclick={() => dispatch("action", "mirror")}
+      onclick={() => onaction?.("mirror")}
       class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
     >
       <!-- Need to flip vertically or similar for Mirror vs Reverse, we'll use ArrowCircleIcon or reverse its scale.
@@ -149,7 +139,7 @@
     </button>
 
     <button
-      onclick={() => dispatch("action", "reverse")}
+      onclick={() => onaction?.("reverse")}
       class="w-full text-left px-4 py-2 hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200 flex items-center gap-2"
     >
       <ArrowCircleIcon className="size-4" strokeWidth={1.5} />
@@ -159,7 +149,7 @@
   <div class="h-px bg-neutral-200 dark:bg-neutral-700 my-1"></div>
 
   <button
-    onclick={() => dispatch("action", "delete")}
+    onclick={() => onaction?.("delete")}
     class="w-full text-left px-4 py-2 hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400 flex items-center gap-2"
   >
     <TrashIcon className="size-4" strokeWidth={1.5} />

--- a/src/lib/components/filemanager/FileGrid.svelte
+++ b/src/lib/components/filemanager/FileGrid.svelte
@@ -1,7 +1,7 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <!-- src/lib/components/filemanager/FileGrid.svelte -->
 <script lang="ts">
-  import { createEventDispatcher, tick, onMount, onDestroy } from "svelte";
+  import { tick, onMount, onDestroy } from "svelte";
   import type { FileInfo, Point, Line } from "../../../types";
   import FileContextMenu from "./FileContextMenu.svelte";
   import PathPreview from "./PathPreview.svelte";
@@ -21,6 +21,13 @@
     renamingFile?: FileInfo | null;
     fieldImage?: string | null;
     showGitStatus?: boolean;
+    onselect?: (file: FileInfo) => void;
+    onopen?: (file: FileInfo) => void;
+    onrenameStart?: (file: FileInfo) => void;
+    onrenameSave?: (name: string) => void;
+    onrenameCancel?: () => void;
+    onmoveFile?: (data: { sourceFile: FileInfo; targetDir: FileInfo }) => void;
+    onmenuAction?: (data: { action: string; file: FileInfo }) => void;
   }
 
   let {
@@ -30,17 +37,14 @@
     renamingFile = null,
     fieldImage = null,
     showGitStatus = true,
+    onselect,
+    onopen,
+    onrenameStart,
+    onrenameSave,
+    onrenameCancel,
+    onmoveFile,
+    onmenuAction,
   }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    select: FileInfo;
-    open: FileInfo;
-    "rename-start": FileInfo;
-    "rename-save": string;
-    "rename-cancel": void;
-    "menu-action": { action: string; file: FileInfo };
-    "move-file": { sourceFile: FileInfo; targetDir: FileInfo };
-  }>();
 
   let contextMenu: { x: number; y: number; file: FileInfo } | null =
     $state(null);
@@ -256,7 +260,7 @@
   function handleContextMenu(event: MouseEvent, file: FileInfo) {
     event.preventDefault();
     contextMenu = { x: event.clientX, y: event.clientY, file };
-    dispatch("select", file);
+    onselect?.(file);
   }
 
   // Open context menu anchored to an element (used by the kebab menu button)
@@ -268,7 +272,7 @@
       y: Math.round(rect.top + 8),
       file,
     };
-    dispatch("select", file);
+    onselect?.(file);
   }
 
   // Wrapper that accepts an Event from the template and forwards a typed element to the anchor
@@ -284,9 +288,9 @@
 
     // Map rename context action to local event
     if (action === "rename") {
-      dispatch("rename-start", file);
+      onrenameStart?.(file);
     } else {
-      dispatch("menu-action", { action, file });
+      onmenuAction?.({ action, file });
     }
   }
 
@@ -426,7 +430,7 @@
       if (data) {
         const sourceFile = JSON.parse(data) as FileInfo;
         if (sourceFile.path !== file.path) {
-          dispatch("move-file", { sourceFile, targetDir: file });
+          onmoveFile?.({ sourceFile, targetDir: file });
         }
       }
     } catch (err) {
@@ -515,8 +519,8 @@
           {dragOverTarget === file.path
             ? 'bg-blue-100 dark:bg-blue-900 ring-2 ring-blue-500'
             : ''}"
-          onclick={() => dispatch("select", file)}
-          ondblclick={() => dispatch("open", file)}
+          onclick={() => onselect?.(file)}
+          ondblclick={() => onopen?.(file)}
           oncontextmenu={(e) => handleContextMenu(e, file)}
           role="button"
           tabindex="0"
@@ -528,7 +532,7 @@
           ondragleave={(e) => handleDragLeave(e, file)}
           ondrop={(e) => handleDrop(e, file)}
           onkeydown={(e) => {
-            if (e.key === "Enter") dispatch("open", file);
+            if (e.key === "Enter") onopen?.(file);
           }}
         >
           <!-- Icon / Preview -->
@@ -634,10 +638,10 @@
                   class="w-full text-xs text-center border border-blue-400 rounded focus:outline-none dark:bg-neutral-700 py-0.5"
                   onkeydown={(e: KeyboardEvent) => {
                     e.stopPropagation();
-                    if (e.key === "Enter") dispatch("rename-save", renameInput);
-                    if (e.key === "Escape") dispatch("rename-cancel");
+                    if (e.key === "Enter") onrenameSave?.(renameInput);
+                    if (e.key === "Escape") onrenameCancel?.();
                   }}
-                  onblur={() => dispatch("rename-cancel")}
+                  onblur={() => onrenameCancel?.()}
                 />
               </div>
             {:else}
@@ -673,7 +677,7 @@
     y={contextMenu.y}
     fileName={contextMenu.file.name}
     isDirectory={contextMenu.file.isDirectory}
-    on:close={() => (contextMenu = null)}
-    on:action={(e) => handleMenuAction(e.detail)}
+    onclose={() => (contextMenu = null)}
+    onaction={(action) => handleMenuAction(action)}
   />
 {/if}

--- a/src/lib/components/filemanager/FileList.svelte
+++ b/src/lib/components/filemanager/FileList.svelte
@@ -1,7 +1,7 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <!-- src/lib/components/filemanager/FileList.svelte -->
 <script lang="ts">
-  import { createEventDispatcher, tick } from "svelte";
+  import { tick } from "svelte";
   import type { FileInfo } from "../../../types";
   import FileContextMenu from "./FileContextMenu.svelte";
   import PathPreview from "./PathPreview.svelte";
@@ -13,16 +13,6 @@
     QuestionMarkIcon,
     EllipsisHorizontalIcon,
   } from "../icons";
-
-  const dispatch = createEventDispatcher<{
-    select: FileInfo;
-    open: FileInfo;
-    "rename-start": FileInfo;
-    "rename-save": string;
-    "rename-cancel": void;
-    "context-menu": { event: MouseEvent; file: FileInfo };
-    "move-file": { sourceFile: FileInfo; targetDir: FileInfo };
-  }>();
 
   let contextMenu: { x: number; y: number; file: FileInfo } | null =
     $state(null);
@@ -223,7 +213,7 @@
       if (data) {
         const sourceFile = JSON.parse(data) as FileInfo;
         if (sourceFile.path !== file.path) {
-          dispatch("move-file", { sourceFile, targetDir: file });
+          onmoveFile?.({ sourceFile, targetDir: file });
         }
       }
     } catch (err) {
@@ -257,7 +247,7 @@
   function handleContextMenu(event: MouseEvent, file: FileInfo) {
     event.preventDefault();
     contextMenu = { x: event.clientX, y: event.clientY, file };
-    dispatch("select", file);
+    onselect?.(file);
   }
 
   function handleMenuAction(action: string) {
@@ -275,9 +265,9 @@
     };
 
     if (action === "rename") {
-      dispatch("rename-start", file);
+      onrenameStart?.(file);
     } else {
-      dispatch("menu-action" as any, { action, file });
+      onmenuAction?.({ action, file });
     }
   }
 
@@ -364,6 +354,13 @@
     sortMode?: "name" | "date";
     renamingFile?: FileInfo | null;
     showGitStatus?: boolean;
+    onselect?: (file: FileInfo) => void;
+    onopen?: (file: FileInfo) => void;
+    onrenameStart?: (file: FileInfo) => void;
+    onrenameSave?: (name: string) => void;
+    onrenameCancel?: () => void;
+    onmoveFile?: (data: { sourceFile: FileInfo; targetDir: FileInfo }) => void;
+    onmenuAction?: (data: { action: string; file: FileInfo }) => void;
   }
 
   let {
@@ -373,6 +370,13 @@
     sortMode = "name",
     renamingFile = null,
     showGitStatus = true,
+    onselect,
+    onopen,
+    onrenameStart,
+    onrenameSave,
+    onrenameCancel,
+    onmoveFile,
+    onmenuAction,
   }: Props = $props();
   onMount(() => setupObserver());
   onDestroy(() => observer && observer.disconnect());
@@ -439,8 +443,8 @@
           {dragOverTarget === file.path
             ? 'bg-blue-100 dark:bg-blue-900 ring-2 ring-blue-500'
             : ''}"
-          onclick={() => dispatch("select", file)}
-          ondblclick={() => dispatch("open", file)}
+          onclick={() => onselect?.(file)}
+          ondblclick={() => onopen?.(file)}
           oncontextmenu={(e) => handleContextMenu(e, file)}
           role="button"
           tabindex="0"
@@ -451,7 +455,7 @@
           ondragleave={(e) => handleDragLeave(e, file)}
           ondrop={(e) => handleDrop(e, file)}
           onkeydown={(e) => {
-            if (e.key === "Enter") dispatch("open", file);
+            if (e.key === "Enter") onopen?.(file);
           }}
         >
           <!-- Icon -->
@@ -496,10 +500,10 @@
                   class="w-full px-1 py-0.5 text-sm border border-blue-400 rounded focus:outline-none dark:bg-neutral-700"
                   onkeydown={(e: KeyboardEvent) => {
                     e.stopPropagation();
-                    if (e.key === "Enter") dispatch("rename-save", renameInput);
-                    if (e.key === "Escape") dispatch("rename-cancel");
+                    if (e.key === "Enter") onrenameSave?.(renameInput);
+                    if (e.key === "Escape") onrenameCancel?.();
                   }}
-                  onblur={() => dispatch("rename-cancel")}
+                  onblur={() => onrenameCancel?.()}
                 />
               </div>
             {:else}
@@ -586,7 +590,7 @@
     y={contextMenu.y}
     fileName={contextMenu.file.name}
     isDirectory={contextMenu.file.isDirectory}
-    on:close={() => (contextMenu = null)}
-    on:action={(e) => handleMenuAction(e.detail)}
+    onclose={() => (contextMenu = null)}
+    onaction={(action) => handleMenuAction(action)}
   />
 {/if}

--- a/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
+++ b/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
@@ -1,22 +1,19 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <!-- src/lib/components/filemanager/FileManagerBreadcrumbs.svelte -->
 <script lang="ts">
-  import { createEventDispatcher, tick } from "svelte";
+  import { tick } from "svelte";
   import { FolderIcon, UndoIcon } from "../icons";
   import { isBrowser } from "../../../utils/platform";
 
   interface Props {
     currentPath: string;
     isAtBase?: boolean;
+    onchangeDir?: (path: string) => void;
+    onchangeDirDialog?: () => void;
+    ongoUp?: () => void;
   }
 
-  let { currentPath, isAtBase = false }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    "change-dir": string;
-    "change-dir-dialog": void;
-    "go-up": void;
-  }>();
+  let { currentPath, isAtBase = false, onchangeDir, onchangeDirDialog, ongoUp }: Props = $props();
 
   let isEditing = $state(false);
   let inputPath = $state("");
@@ -66,7 +63,7 @@
     if (!isEditing) return;
     isEditing = false;
     if (inputPath !== currentPath && inputPath.trim() !== "") {
-      dispatch("change-dir", inputPath.trim());
+      onchangeDir?.(inputPath.trim());
     }
   }
 
@@ -96,7 +93,7 @@
     {#if !isAtBase}
       <button
         class="p-1 mr-2 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 shrink-0"
-        onclick={() => dispatch("go-up")}
+        onclick={() => ongoUp?.()}
         title="Go up one directory"
         aria-label="Go Up"
       >
@@ -116,7 +113,7 @@
 
     {#if !isBrowser}
       <button
-        onclick={() => dispatch("change-dir-dialog")}
+        onclick={() => onchangeDirDialog?.()}
         class="p-1 ml-1 text-neutral-500 hover:text-blue-600 dark:text-neutral-400 dark:hover:text-blue-400 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         title="Change Directory"
         aria-label="Change Directory"

--- a/src/lib/components/tools/ContextMenu.svelte
+++ b/src/lib/components/tools/ContextMenu.svelte
@@ -1,6 +1,6 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
-  import { createEventDispatcher, onMount, tick } from "svelte";
+  import { onMount, tick } from "svelte";
   import { fade } from "svelte/transition";
   import { menuNavigation } from "../../actions/menuNavigation";
 
@@ -17,20 +17,17 @@
       disabled?: boolean;
       shortcut?: string;
     }[];
+    onclose?: () => void;
+    onaction?: (action: string) => void;
   }
 
-  let { x, y, items = [] }: Props = $props();
-
-  const dispatch = createEventDispatcher<{
-    close: void;
-    action: string; // fallback if onClick is not provided
-  }>();
+  let { x, y, items = [], onclose, onaction }: Props = $props();
 
   let menuElement: HTMLDivElement | undefined = $state();
 
   function handleClickOutside(event: MouseEvent) {
     if (menuElement && !menuElement.contains(event.target as Node)) {
-      dispatch("close");
+      onclose?.();
     }
   }
 
@@ -93,16 +90,16 @@
     if (item.onClick) {
       item.onClick();
     } else if (item.action) {
-      dispatch("action", item.action);
+      onaction?.(item.action);
     }
-    dispatch("close");
+    onclose?.();
   }
 </script>
 
 <div
   use:portal
   use:menuNavigation
-  onclose={() => dispatch("close")}
+  onclose={() => onclose?.()}
   bind:this={menuElement}
   class="fixed z-[9999] min-w-[180px] py-1 bg-white dark:bg-neutral-800 rounded-lg shadow-xl border border-neutral-200 dark:border-neutral-700 text-sm select-none"
   style="top: {adjustedY}px; left: {adjustedX}px;"


### PR DESCRIPTION
Migrated components from Svelte 4 `createEventDispatcher` to Svelte 5 callback props.

---
*PR created automatically by Jules for task [17814952642269637487](https://jules.google.com/task/17814952642269637487) started by @Mallen220*