### PR TITLE
fix: improve keyboard shortcut focus detection for non-text inputs and sliders

### DIFF
--- a/src/config/sidebarItems.ts
+++ b/src/config/sidebarItems.ts
@@ -18,7 +18,6 @@ import {
   OnionSkinIcon,
   VelocityHeatmapIcon,
   LockIcon,
-  UnlockIcon,
   FeedbackIcon,
   GithubIcon,
   ShowRobotIcon,

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -538,9 +538,10 @@
   }
 
   // File Operations
-  async function handleMoveFile(
-    data: { sourceFile: FileInfo; targetDir: FileInfo },
-  ) {
+  async function handleMoveFile(data: {
+    sourceFile: FileInfo;
+    targetDir: FileInfo;
+  }) {
     const { sourceFile, targetDir } = data;
     if (!targetDir.isDirectory) return;
     if (sourceFile.path === targetDir.path) return;

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(window, { key: "Escape" });
+    await fireEvent.keyDown(globalThis, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/filemanager/FileContextMenu.svelte
+++ b/src/lib/components/filemanager/FileContextMenu.svelte
@@ -19,10 +19,26 @@
     fileName: string;
     isDirectory?: boolean;
     onclose?: () => void;
-    onaction?: (action: "open" | "rename" | "delete" | "duplicate" | "mirror" | "reverse" | "save-to") => void;
+    onaction?: (
+      action:
+        | "open"
+        | "rename"
+        | "delete"
+        | "duplicate"
+        | "mirror"
+        | "reverse"
+        | "save-to",
+    ) => void;
   }
 
-  let { x, y, fileName, isDirectory = false, onclose, onaction }: Props = $props();
+  let {
+    x,
+    y,
+    fileName,
+    isDirectory = false,
+    onclose,
+    onaction,
+  }: Props = $props();
 
   let menuElement: HTMLDivElement | undefined = $state();
 

--- a/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
+++ b/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
@@ -13,7 +13,13 @@
     ongoUp?: () => void;
   }
 
-  let { currentPath, isAtBase = false, onchangeDir, onchangeDirDialog, ongoUp }: Props = $props();
+  let {
+    currentPath,
+    isAtBase = false,
+    onchangeDir,
+    onchangeDirDialog,
+    ongoUp,
+  }: Props = $props();
 
   let isEditing = $state(false);
   let inputPath = $state("");

--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -8,9 +8,23 @@ export function isInputFocused(): boolean {
   const el = document.activeElement as HTMLElement | null;
   if (!el) return false;
   const tag = el.tagName;
+  const isTextInput =
+    tag === "INPUT" &&
+    ![
+      "button",
+      "submit",
+      "reset",
+      "checkbox",
+      "radio",
+      "range",
+      "color",
+      "file",
+    ].includes((el.getAttribute("type") || "").toLowerCase());
   return (
-    ["INPUT", "TEXTAREA", "SELECT"].includes(tag) ||
-    (el as any).isContentEditable
+    isTextInput ||
+    tag === "TEXTAREA" ||
+    tag === "SELECT" ||
+    !!(el as any).isContentEditable
   );
 }
 
@@ -22,7 +36,11 @@ export function isButtonFocused(): boolean {
   const el = document.activeElement as HTMLElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  return tag === "BUTTON" || el.getAttribute("role") === "button";
+  return (
+    tag === "BUTTON" ||
+    el.getAttribute("role") === "button" ||
+    el.getAttribute("role") === "slider"
+  );
 }
 
 export function shouldBlockShortcut(


### PR DESCRIPTION
This PR fixes an issue where focusing on non-text inputs (like range sliders) or ARIA slider components would unintentionally block all global keyboard shortcuts. 

By updating `isInputFocused` and `isButtonFocused` in `src/lib/components/shortcuts/utils.ts`, text-inputs are properly identified to suppress keybinds, while non-text interactive elements correctly allow global keybinds (except for interaction keys like Space and Enter).

---
*PR created automatically by Jules for task [12709805421475598369](https://jules.google.com/task/12709805421475598369) started by @Mallen220*