### PR TITLE
Refine keyboard shortcut focus detection for non-text inputs

### DIFF
--- a/src/config/sidebarItems.ts
+++ b/src/config/sidebarItems.ts
@@ -18,7 +18,6 @@ import {
   OnionSkinIcon,
   VelocityHeatmapIcon,
   LockIcon,
-  UnlockIcon,
   FeedbackIcon,
   GithubIcon,
   ShowRobotIcon,

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -538,9 +538,10 @@
   }
 
   // File Operations
-  async function handleMoveFile(
-    data: { sourceFile: FileInfo; targetDir: FileInfo },
-  ) {
+  async function handleMoveFile(data: {
+    sourceFile: FileInfo;
+    targetDir: FileInfo;
+  }) {
     const { sourceFile, targetDir } = data;
     if (!targetDir.isDirectory) return;
     if (sourceFile.path === targetDir.path) return;

--- a/src/lib/components/filemanager/FileContextMenu.svelte
+++ b/src/lib/components/filemanager/FileContextMenu.svelte
@@ -19,10 +19,26 @@
     fileName: string;
     isDirectory?: boolean;
     onclose?: () => void;
-    onaction?: (action: "open" | "rename" | "delete" | "duplicate" | "mirror" | "reverse" | "save-to") => void;
+    onaction?: (
+      action:
+        | "open"
+        | "rename"
+        | "delete"
+        | "duplicate"
+        | "mirror"
+        | "reverse"
+        | "save-to",
+    ) => void;
   }
 
-  let { x, y, fileName, isDirectory = false, onclose, onaction }: Props = $props();
+  let {
+    x,
+    y,
+    fileName,
+    isDirectory = false,
+    onclose,
+    onaction,
+  }: Props = $props();
 
   let menuElement: HTMLDivElement | undefined = $state();
 

--- a/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
+++ b/src/lib/components/filemanager/FileManagerBreadcrumbs.svelte
@@ -13,7 +13,13 @@
     ongoUp?: () => void;
   }
 
-  let { currentPath, isAtBase = false, onchangeDir, onchangeDirDialog, ongoUp }: Props = $props();
+  let {
+    currentPath,
+    isAtBase = false,
+    onchangeDir,
+    onchangeDirDialog,
+    ongoUp,
+  }: Props = $props();
 
   let isEditing = $state(false);
   let inputPath = $state("");

--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -5,13 +5,30 @@ import { sequenceStore } from "../../projectStore";
 import { actionRegistry } from "../../actionRegistry";
 
 export function isInputFocused(): boolean {
-  const el = document.activeElement as HTMLElement | null;
+  const el = document.activeElement as HTMLInputElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  return (
-    ["INPUT", "TEXTAREA", "SELECT"].includes(tag) ||
-    (el as any).isContentEditable
-  );
+
+  if (tag === "INPUT") {
+    const type = el.type ? el.type.toLowerCase() : "text";
+    const nonTextTypes = [
+      "checkbox",
+      "radio",
+      "range",
+      "button",
+      "submit",
+      "reset",
+      "color",
+      "file",
+      "image",
+    ];
+    if (nonTextTypes.includes(type)) {
+      return false;
+    }
+    return true;
+  }
+
+  return ["TEXTAREA", "SELECT"].includes(tag) || (el as any).isContentEditable;
 }
 
 export function isUIElementFocused(): boolean {
@@ -19,10 +36,27 @@ export function isUIElementFocused(): boolean {
 }
 
 export function isButtonFocused(): boolean {
-  const el = document.activeElement as HTMLElement | null;
+  const el = document.activeElement as HTMLInputElement | null;
   if (!el) return false;
   const tag = el.tagName;
-  return tag === "BUTTON" || el.getAttribute("role") === "button";
+
+  if (tag === "INPUT") {
+    const type = el.type ? el.type.toLowerCase() : "text";
+    const buttonTypes = [
+      "checkbox",
+      "radio",
+      "range",
+      "button",
+      "submit",
+      "reset",
+    ];
+    if (buttonTypes.includes(type)) return true;
+  }
+
+  const role = el.getAttribute("role");
+  const buttonRoles = ["button", "slider", "switch", "checkbox", "radio"];
+
+  return tag === "BUTTON" || (role !== null && buttonRoles.includes(role));
 }
 
 export function shouldBlockShortcut(


### PR DESCRIPTION
This commit addresses an issue with keyboard shortcuts where interacting with non-text inputs (such as range sliders, toggles, checkboxes, and buttons) would incorrectly flag the UI as "input focused," thereby swallowing or blocking global hotkeys. 

The focus detection utility functions `isInputFocused` and `isButtonFocused` were rewritten to properly inspect the `type` attribute of `<input>` elements and common ARIA roles (`role="slider"`, `role="switch"`, etc.) to distinguish true text-editing inputs from interactive UI buttons. Additionally, fixed a `globalThis` typing issue in a unit test to pass `svelte-check`.

---
*PR created automatically by Jules for task [17267846077153315089](https://jules.google.com/task/17267846077153315089) started by @Mallen220*