### PR TITLE
refactor: remove unused variables in PreviewPathGenerator

### DIFF
--- a/src/lib/components/renderer/PreviewPathGenerator.ts
+++ b/src/lib/components/renderer/PreviewPathGenerator.ts
@@ -12,7 +12,7 @@ export function generatePreviewPathElements(
   ctx: RenderContext,
 ) {
   let _previewPaths: Path[] = [];
-  const { x, y, uiLength } = ctx;
+  const { uiLength } = ctx;
 
   if (previewOptimizedLines && previewOptimizedLines.length > 0) {
     previewOptimizedLines.forEach((line, idx) => {


### PR DESCRIPTION
This PR cleans up `src/lib/components/renderer/PreviewPathGenerator.ts` by removing the unused destructured variables `x` and `y` from the `ctx` object, fixing a linting error (`no-unused-vars`). Tests have been run and verified.

---
*PR created automatically by Jules for task [14312163615092745139](https://jules.google.com/task/14312163615092745139) started by @Mallen220*