### PR TITLE
Add non-intrusive update notification for Microsoft Store users

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -102,6 +102,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   // Update
   onUpdateAvailable: (callback) =>
     ipcRenderer.on("update-available", (_event, data) => callback(data)),
+  onStoreUpdateAvailable: (callback) =>
+    ipcRenderer.on("store-update-available", (_event, data) => callback(data)),
   downloadUpdate: (version, url) =>
     ipcRenderer.invoke("update:download", version, url),
   skipUpdate: (version) => ipcRenderer.invoke("update:skip", version),

--- a/electron/updater.js
+++ b/electron/updater.js
@@ -18,14 +18,6 @@ class AppUpdater {
 
   async checkForUpdates(manual = false) {
     try {
-      // Check if running in Microsoft Store context
-      if (process.windowsStore) {
-        console.log(
-          "Running in Microsoft Store context. Skipping GitHub update check.",
-        );
-        return { updateAvailable: false, reason: "store" };
-      }
-
       console.log("Checking for updates...");
 
       // GitHub API URL for your repository releases
@@ -53,7 +45,15 @@ class AppUpdater {
       }
 
       if (this.isNewerVersion(latestVersion, this.currentVersion)) {
-        this.showUpdateAvailableDialog(releaseData, manual ? 0 : 3000);
+        if (process.windowsStore) {
+          if (this?.mainWindow?.webContents) {
+            this.mainWindow.webContents.send("store-update-available", {
+              version: latestVersion,
+            });
+          }
+        } else {
+          this.showUpdateAvailableDialog(releaseData, manual ? 0 : 3000);
+        }
         return { updateAvailable: true, version: latestVersion, releaseData };
       } else {
         console.log("Application is up to date.");

--- a/electron/updater.test.js
+++ b/electron/updater.test.js
@@ -72,11 +72,25 @@ describe("updater.js", () => {
   });
 
   describe("checkForUpdates", () => {
-    it("skips check if running in Microsoft Store", async () => {
+    it("triggers store-update-available if running in Microsoft Store", async () => {
       process.windowsStore = true;
+      const releaseData = {
+        tag_name: "v2.0.0",
+        body: "notes",
+        html_url: "url",
+      };
+      globalThis.fetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => releaseData,
+      });
+
       const result = await updater.checkForUpdates();
-      expect(result.updateAvailable).toBe(false);
-      expect(result.reason).toBe("store");
+      expect(result.updateAvailable).toBe(true);
+      expect(result.version).toBe("2.0.0");
+      expect(mockWindow.webContents.send).toHaveBeenCalledWith(
+        "store-update-available",
+        { version: "2.0.0" },
+      );
       delete process.windowsStore;
     });
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -69,6 +69,7 @@
     ratingDialogAutoOpened,
     gitStatusStore,
     showTransformDialog,
+    notification,
   } from "./stores";
 
   // keep a locally-named binding for the watchers and template
@@ -160,6 +161,7 @@
     gitShow?: (filePath: string) => Promise<string | null>;
     isWindowsStore?: () => Promise<boolean>;
     onUpdateAvailable?: (callback: (data: any) => void) => void;
+    onStoreUpdateAvailable?: (callback: (data: any) => void) => void;
     downloadUpdate?: (version: string, url: string) => void;
     skipUpdate?: (version: string) => void;
   }
@@ -247,6 +249,23 @@
       electronAPI.onUpdateAvailable((data: any) => {
         updateDataStore.set(data);
         showUpdateAvailableDialog.set(true);
+      });
+    }
+
+    if (electronAPI && electronAPI.onStoreUpdateAvailable) {
+      electronAPI.onStoreUpdateAvailable((data: any) => {
+        notification.set({
+          message: `Update ${data.version} is available in the Microsoft Store.`,
+          type: "info",
+          timeout: 0,
+          actionLabel: "Open Store",
+          action: () => {
+            if (electronAPI.openExternal)
+              electronAPI.openExternal(
+                "https://apps.microsoft.com/store/detail/9NK0B4FDJ3ZW?cid=DevShareMCLPCS",
+              );
+          },
+        });
       });
     }
 

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(window, { key: "Escape" });
+    await fireEvent.keyDown(globalThis, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This change implements a non-intrusive update notification for Microsoft Store users. Instead of the Electron updater either skipping update checks entirely or displaying an intrusive update dialog that tries to download from GitHub, it now dispatches a `store-update-available` IPC message. The Svelte frontend listens for this message and triggers a subtle toast notification that links the user directly to the Microsoft Store page, allowing for a better user experience.

---
*PR created automatically by Jules for task [11554902446349050042](https://jules.google.com/task/11554902446349050042) started by @Mallen220*