### PR TITLE
feat: expand whitelist for global keyboard shortcuts

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -65,6 +65,21 @@ export function shouldBlockShortcut(
 ): boolean {
   // Whitelist specific actions that should work even when input is focused
   if (
+    actionId === "open-file" ||
+    actionId === "new-file" ||
+    actionId === "toggle-file-manager" ||
+    actionId === "export-java" ||
+    actionId === "export-points" ||
+    actionId === "export-sequential" ||
+    actionId === "export-pp" ||
+    actionId === "clear-obstacles" ||
+    actionId === "toggle-plugin-manager" ||
+    actionId === "copy-code" ||
+    actionId === "copy-table" ||
+    actionId === "download-java" ||
+    actionId === "focus-path-list" ||
+    actionId === "focus-code-editor" ||
+    actionId === "confirm-dialog" ||
     actionId === "toggle-command-palette" ||
     actionId === "show-help" ||
     actionId === "cycle-tabs-next" ||


### PR DESCRIPTION
This PR adds several missing global commands to the `shouldBlockShortcut` exclusions list in `utils.ts`. Prior to this change, actions like "Save Project As", "Export Java", or "New File" would be blocked if the user happened to have focus inside a text input field, despite those shortcuts relying on `Ctrl`/`Cmd` modifiers that do not conflict with normal typing. 

Adding these action IDs to the whitelist ensures these commands behave consistently across the application regardless of focus state, contributing to better keybind support and an improved UX.

Fixes # (issue)

---
*PR created automatically by Jules for task [5297708240790138227](https://jules.google.com/task/5297708240790138227) started by @Mallen220*