### PR TITLE
Remove unused Svelte 4 event listener for previewing optimized lines

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1104,9 +1104,6 @@
     previewOptimizedLines = newLines;
   }
 
-  function handleNavbarPreviewChange(e: CustomEvent) {
-    previewOptimizedLines = e.detail;
-  }
 
   function stepForward() {
     const p = Math.min(100, percent + 1);
@@ -1897,7 +1894,6 @@
         {canUndo}
         {canRedo}
         {history}
-        on:previewOptimizedLines={handleNavbarPreviewChange}
       />
     </div>
   {/if}

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(globalThis, { key: "Escape" });
+    await fireEvent.keyDown(window, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(window, { key: "Escape" });
+    await fireEvent.keyDown(window as unknown as Window, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(window as unknown as Window, { key: "Escape" });
+    await fireEvent.keyDown(document.body, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Cleaned up some legacy Svelte 4 logic by removing an obsolete event listener. Also fixed a related test compilation issue to ensure the build stays clean.

---
*PR created automatically by Jules for task [7539887168447600277](https://jules.google.com/task/7539887168447600277) started by @Mallen220*