### PR TITLE
✨ Feature: Shift+Drag Box Selection

### DIFF
--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -207,6 +207,63 @@
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function checkEventMarkerSelections(
+    line: any,
+    lIdx: number,
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+    newSelections: string[],
+  ) {
+    if (!line.eventMarkers) return;
+    line.eventMarkers.forEach((em: any, eIdx: number) => {
+      if (em.type === "pose" && em.poseX !== undefined && em.poseY !== undefined) {
+        if (isPointInBox(em.poseX, em.poseY, minX, maxX, minY, maxY)) {
+          newSelections.push(`event-${lIdx}-${eIdx}`);
+        }
+      }
+    });
+  }
+
+  function checkLineSelections(
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+    newSelections: string[],
+  ) {
+    lines.forEach((line, lIdx) => {
+      if (isPointInBox(line.endPoint.x, line.endPoint.y, minX, maxX, minY, maxY)) {
+        newSelections.push(`point-${lIdx + 1}-0`);
+      }
+      line.controlPoints.forEach((cp, cpIdx) => {
+        if (isPointInBox(cp.x, cp.y, minX, maxX, minY, maxY)) {
+          newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
+        }
+      });
+      checkEventMarkerSelections(line, lIdx, minX, maxX, minY, maxY, newSelections);
+    });
+  }
+
+  function checkObstacleSelections(
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+    newSelections: string[],
+  ) {
+    shapes.forEach((shape, sIdx) => {
+      if (!shape.vertices) return;
+      shape.vertices.forEach((v, vIdx) => {
+        if (isPointInBox(v.x, v.y, minX, maxX, minY, maxY)) {
+          newSelections.push(`obstacle-${sIdx}-${vIdx}`);
+        }
+      });
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   function handleBoxSelectionComplete(
     minX: number,
     maxX: number,
@@ -219,41 +276,8 @@
       newSelections.push("point-0-0");
     }
 
-    lines.forEach((line, lIdx) => {
-      if (
-        isPointInBox(line.endPoint.x, line.endPoint.y, minX, maxX, minY, maxY)
-      ) {
-        newSelections.push(`point-${lIdx + 1}-0`);
-      }
-      line.controlPoints.forEach((cp, cpIdx) => {
-        if (isPointInBox(cp.x, cp.y, minX, maxX, minY, maxY)) {
-          newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
-        }
-      });
-      if (line.eventMarkers) {
-        line.eventMarkers.forEach((em, eIdx) => {
-          if (
-            em.type === "pose" &&
-            em.poseX !== undefined &&
-            em.poseY !== undefined
-          ) {
-            if (isPointInBox(em.poseX, em.poseY, minX, maxX, minY, maxY)) {
-              newSelections.push(`event-${lIdx}-${eIdx}`);
-            }
-          }
-        });
-      }
-    });
-
-    shapes.forEach((shape, sIdx) => {
-      if (shape.vertices) {
-        shape.vertices.forEach((v, vIdx) => {
-          if (isPointInBox(v.x, v.y, minX, maxX, minY, maxY)) {
-            newSelections.push(`obstacle-${sIdx}-${vIdx}`);
-          }
-        });
-      }
-    });
+    checkLineSelections(minX, maxX, minY, maxY, newSelections);
+    checkObstacleSelections(minX, maxX, minY, maxY, newSelections);
 
     if (newSelections.length > 0) {
       multiSelectedPointIds.update((ids) => {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -475,7 +475,7 @@
         // Optimization: Don't use elementFromPoint here. It forces a reflow.
 
         if (isBoxSelecting && boxSelectStart && boxSelectElement) {
-          boxSelectCurrent = { x: currentMouseX, y: currentMouseY };
+          boxSelectCurrent = { x: rawInchXForDisplay, y: rawInchYForDisplay };
 
           const minX = Math.min(boxSelectStart.x, boxSelectCurrent.x);
           const maxX = Math.max(boxSelectStart.x, boxSelectCurrent.x);
@@ -1204,7 +1204,7 @@
             );
             boxSelectElement.fill = "rgba(59, 130, 246, 0.2)"; // blue-500 with opacity
             boxSelectElement.stroke = "#3b82f6";
-            boxSelectElement.linewidth = uiLength(1.5);
+            boxSelectElement.linewidth = 1;
             two!.add(boxSelectElement);
             two!.update();
             return;

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -172,6 +172,13 @@
   let isDown = false;
   let isPanning = false;
   let isDrawing = false;
+
+  // Box Selection State
+  let isBoxSelecting = false;
+  let boxSelectStart: { x: number; y: number } | null = null;
+  let boxSelectCurrent: { x: number; y: number } | null = null;
+  let boxSelectElement: InstanceType<typeof Two.Path> | null = null;
+
   let drawPoints: { x: number; y: number }[] = [];
   let drawPathElement: InstanceType<typeof Two.Path> | null = null;
   let multiDragOffsets = new Map<string, { x: number; y: number }>();
@@ -467,7 +474,32 @@
         // Cursor and Dragging Logic
         // Optimization: Don't use elementFromPoint here. It forces a reflow.
 
-        if (isDown && currentElem) {
+        if (isBoxSelecting && boxSelectStart && boxSelectElement) {
+          boxSelectCurrent = { x: currentMouseX, y: currentMouseY };
+
+          const minX = Math.min(boxSelectStart.x, boxSelectCurrent.x);
+          const maxX = Math.max(boxSelectStart.x, boxSelectCurrent.x);
+          const minY = Math.min(boxSelectStart.y, boxSelectCurrent.y);
+          const maxY = Math.max(boxSelectStart.y, boxSelectCurrent.y);
+
+          // Update rectangle vertices
+          // Using Anchor because Two.Path uses Anchor objects for vertices
+          const p1x = x(minX);
+          const p1y = y(minY);
+          const p2x = x(maxX);
+          const p2y = y(minY);
+          const p3x = x(maxX);
+          const p3y = y(maxY);
+          const p4x = x(minX);
+          const p4y = y(maxY);
+
+          boxSelectElement.vertices[0].set(p1x, p1y);
+          boxSelectElement.vertices[1].set(p2x, p2y);
+          boxSelectElement.vertices[2].set(p3x, p3y);
+          boxSelectElement.vertices[3].set(p4x, p4y);
+
+          two!.update();
+        } else if (isDown && currentElem) {
           // Dragging Logic
 
           let linesChanged = false;
@@ -1137,11 +1169,51 @@
           }
         }
 
-        if (!clickedElem && !evt.shiftKey && !evt.ctrlKey && !evt.metaKey) {
-          selectedPointId.set(null);
-          selectedLineId.set(null);
-          multiSelectedPointIds.set([]);
-          multiSelectedLineIds.set([]);
+        if (!clickedElem) {
+          if (evt.shiftKey) {
+            // Start Box Selection
+            isBoxSelecting = true;
+
+            const rectForMouse =
+              two!.renderer.domElement.getBoundingClientRect();
+            const transformedForMouse = getTransformedCoordinates(
+              evt.clientX,
+              evt.clientY,
+              rectForMouse,
+              settings.fieldRotation || 0,
+            );
+            let inchX = x.invert(transformedForMouse.x);
+            let inchY = y.invert(transformedForMouse.y);
+
+            boxSelectStart = { x: inchX, y: inchY };
+            boxSelectCurrent = { x: inchX, y: inchY };
+
+            if (boxSelectElement) boxSelectElement.remove();
+
+            // Create a path for the box
+            boxSelectElement = two!.makePath(
+              x(inchX),
+              y(inchY),
+              x(inchX),
+              y(inchY),
+              x(inchX),
+              y(inchY),
+              x(inchX),
+              y(inchY),
+              true as any,
+            );
+            boxSelectElement.fill = "rgba(59, 130, 246, 0.2)"; // blue-500 with opacity
+            boxSelectElement.stroke = "#3b82f6";
+            boxSelectElement.linewidth = uiLength(1.5);
+            two!.add(boxSelectElement);
+            two!.update();
+            return;
+          } else if (!evt.ctrlKey && !evt.metaKey) {
+            selectedPointId.set(null);
+            selectedLineId.set(null);
+            multiSelectedPointIds.set([]);
+            multiSelectedLineIds.set([]);
+          }
         }
 
         if (clickedElem) {
@@ -1456,6 +1528,119 @@
 
     two!.renderer.domElement.addEventListener("mouseup", () => {
       snapGuides = [];
+      if (isBoxSelecting) {
+        isBoxSelecting = false;
+        if (boxSelectElement) {
+          boxSelectElement.remove();
+          boxSelectElement = null;
+          two!.update();
+        }
+
+        if (boxSelectStart && boxSelectCurrent) {
+          const minX = Math.min(boxSelectStart.x, boxSelectCurrent.x);
+          const maxX = Math.max(boxSelectStart.x, boxSelectCurrent.x);
+          const minY = Math.min(boxSelectStart.y, boxSelectCurrent.y);
+          const maxY = Math.max(boxSelectStart.y, boxSelectCurrent.y);
+
+          // We only want to select if the box has some area to prevent accidental tiny selections
+          if (maxX - minX > 0.5 || maxY - minY > 0.5) {
+            const newSelections: string[] = [];
+
+            // Check start point
+            if (
+              startPoint.x >= minX &&
+              startPoint.x <= maxX &&
+              startPoint.y >= minY &&
+              startPoint.y <= maxY
+            ) {
+              newSelections.push("point-0-0");
+            }
+
+            // Check paths
+            lines.forEach((line, lIdx) => {
+              if (
+                line.endPoint.x >= minX &&
+                line.endPoint.x <= maxX &&
+                line.endPoint.y >= minY &&
+                line.endPoint.y <= maxY
+              ) {
+                newSelections.push(`point-${lIdx + 1}-0`);
+              }
+              line.controlPoints.forEach((cp, cpIdx) => {
+                if (
+                  cp.x >= minX &&
+                  cp.x <= maxX &&
+                  cp.y >= minY &&
+                  cp.y <= maxY
+                ) {
+                  newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
+                }
+              });
+              if (line.eventMarkers) {
+                line.eventMarkers.forEach((em, eIdx) => {
+                  if (
+                    em.type === "pose" &&
+                    em.poseX !== undefined &&
+                    em.poseY !== undefined
+                  ) {
+                    if (
+                      em.poseX >= minX &&
+                      em.poseX <= maxX &&
+                      em.poseY >= minY &&
+                      em.poseY <= maxY
+                    ) {
+                      newSelections.push(`event-${lIdx}-${eIdx}`);
+                    }
+                  }
+                });
+              }
+            });
+
+            // Check obstacles
+            shapes.forEach((shape, sIdx) => {
+              if (shape.vertices) {
+                shape.vertices.forEach((v, vIdx) => {
+                  if (
+                    v.x >= minX &&
+                    v.x <= maxX &&
+                    v.y >= minY &&
+                    v.y <= maxY
+                  ) {
+                    newSelections.push(`obstacle-${sIdx}-${vIdx}`);
+                  }
+                });
+              }
+            });
+
+            if (newSelections.length > 0) {
+              multiSelectedPointIds.update((ids) => {
+                const set = new Set([...ids, ...newSelections]);
+                return Array.from(set);
+              });
+
+              // Set selectedLineId if we selected path points, to keep UI consistent
+              const firstLineId = newSelections.find((s) =>
+                s.startsWith("point-"),
+              );
+              if (firstLineId && firstLineId !== "point-0-0") {
+                const parts = firstLineId.split("-");
+                const lIdx = Number(parts[1]) - 1;
+                if (lines[lIdx]) selectedLineId.set(lines[lIdx].id as string);
+              }
+
+              notification.set({
+                message: `Selected ${newSelections.length} items`,
+                type: "info",
+                timeout: 1500,
+              });
+            }
+          }
+        }
+        boxSelectStart = null;
+        boxSelectCurrent = null;
+        return;
+      }
+
       if ($isDrawingMode && isDrawing) {
         isDrawing = false;
         if (drawPathElement) {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -195,6 +195,87 @@
 
   // Follow Robot Logic (Loop for playback)
   let followLoopId: number;
+  function isPointInBox(
+    px: number,
+    py: number,
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+  ) {
+    return px >= minX && px <= maxX && py >= minY && py <= maxY;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function handleBoxSelectionComplete(
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+  ) {
+    const newSelections: string[] = [];
+
+    if (isPointInBox(startPoint.x, startPoint.y, minX, maxX, minY, maxY)) {
+      newSelections.push("point-0-0");
+    }
+
+    lines.forEach((line, lIdx) => {
+      if (
+        isPointInBox(line.endPoint.x, line.endPoint.y, minX, maxX, minY, maxY)
+      ) {
+        newSelections.push(`point-${lIdx + 1}-0`);
+      }
+      line.controlPoints.forEach((cp, cpIdx) => {
+        if (isPointInBox(cp.x, cp.y, minX, maxX, minY, maxY)) {
+          newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
+        }
+      });
+      if (line.eventMarkers) {
+        line.eventMarkers.forEach((em, eIdx) => {
+          if (
+            em.type === "pose" &&
+            em.poseX !== undefined &&
+            em.poseY !== undefined
+          ) {
+            if (isPointInBox(em.poseX, em.poseY, minX, maxX, minY, maxY)) {
+              newSelections.push(`event-${lIdx}-${eIdx}`);
+            }
+          }
+        });
+      }
+    });
+
+    shapes.forEach((shape, sIdx) => {
+      if (shape.vertices) {
+        shape.vertices.forEach((v, vIdx) => {
+          if (isPointInBox(v.x, v.y, minX, maxX, minY, maxY)) {
+            newSelections.push(`obstacle-${sIdx}-${vIdx}`);
+          }
+        });
+      }
+    });
+
+    if (newSelections.length > 0) {
+      multiSelectedPointIds.update((ids) => {
+        const set = new Set([...ids, ...newSelections]);
+        return Array.from(set);
+      });
+
+      const firstLineId = newSelections.find((s) => s.startsWith("point-"));
+      if (firstLineId && firstLineId !== "point-0-0") {
+        const parts = firstLineId.split("-");
+        const lIdx = Number(parts[1]) - 1;
+        if (lines[lIdx]) selectedLineId.set(lines[lIdx].id as string);
+      }
+
+      notification.set({
+        message: `Selected ${newSelections.length} items`,
+        type: "info",
+        timeout: 1500,
+      });
+    }
+  }
+
   function followLoop() {
     if ($followRobotStore && $playingStore && robotXY) {
       panToField(robotXY.x, robotXY.y);
@@ -1544,96 +1625,7 @@
 
           // We only want to select if the box has some area to prevent accidental tiny selections
           if (maxX - minX > 0.5 || maxY - minY > 0.5) {
-            const newSelections: string[] = [];
-
-            // Check start point
-            if (
-              startPoint.x >= minX &&
-              startPoint.x <= maxX &&
-              startPoint.y >= minY &&
-              startPoint.y <= maxY
-            ) {
-              newSelections.push("point-0-0");
-            }
-
-            // Check paths
-            lines.forEach((line, lIdx) => {
-              if (
-                line.endPoint.x >= minX &&
-                line.endPoint.x <= maxX &&
-                line.endPoint.y >= minY &&
-                line.endPoint.y <= maxY
-              ) {
-                newSelections.push(`point-${lIdx + 1}-0`);
-              }
-              line.controlPoints.forEach((cp, cpIdx) => {
-                if (
-                  cp.x >= minX &&
-                  cp.x <= maxX &&
-                  cp.y >= minY &&
-                  cp.y <= maxY
-                ) {
-                  newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
-                }
-              });
-              if (line.eventMarkers) {
-                line.eventMarkers.forEach((em, eIdx) => {
-                  if (
-                    em.type === "pose" &&
-                    em.poseX !== undefined &&
-                    em.poseY !== undefined
-                  ) {
-                    if (
-                      em.poseX >= minX &&
-                      em.poseX <= maxX &&
-                      em.poseY >= minY &&
-                      em.poseY <= maxY
-                    ) {
-                      newSelections.push(`event-${lIdx}-${eIdx}`);
-                    }
-                  }
-                });
-              }
-            });
-
-            // Check obstacles
-            shapes.forEach((shape, sIdx) => {
-              if (shape.vertices) {
-                shape.vertices.forEach((v, vIdx) => {
-                  if (
-                    v.x >= minX &&
-                    v.x <= maxX &&
-                    v.y >= minY &&
-                    v.y <= maxY
-                  ) {
-                    newSelections.push(`obstacle-${sIdx}-${vIdx}`);
-                  }
-                });
-              }
-            });
-
-            if (newSelections.length > 0) {
-              multiSelectedPointIds.update((ids) => {
-                const set = new Set([...ids, ...newSelections]);
-                return Array.from(set);
-              });
-
-              // Set selectedLineId if we selected path points, to keep UI consistent
-              const firstLineId = newSelections.find((s) =>
-                s.startsWith("point-"),
-              );
-              if (firstLineId && firstLineId !== "point-0-0") {
-                const parts = firstLineId.split("-");
-                const lIdx = Number(parts[1]) - 1;
-                if (lines[lIdx]) selectedLineId.set(lines[lIdx].id as string);
-              }
-
-              notification.set({
-                message: `Selected ${newSelections.length} items`,
-                type: "info",
-                timeout: 1500,
-              });
-            }
+            handleBoxSelectionComplete(minX, maxX, minY, maxY);
           }
         }
         boxSelectStart = null;

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -177,7 +177,7 @@
   let isBoxSelecting = false;
   let boxSelectStart: { x: number; y: number } | null = null;
   let boxSelectCurrent: { x: number; y: number } | null = null;
-  let boxSelectElement: InstanceType<typeof Two.Path> | null = null;
+  let boxSelectElement: InstanceType<typeof Two.Rectangle> | null = null;
 
   let drawPoints: { x: number; y: number }[] = [];
   let drawPathElement: InstanceType<typeof Two.Path> | null = null;
@@ -563,21 +563,19 @@
           const minY = Math.min(boxSelectStart.y, boxSelectCurrent.y);
           const maxY = Math.max(boxSelectStart.y, boxSelectCurrent.y);
 
-          // Update rectangle vertices
-          // Using Anchor because Two.Path uses Anchor objects for vertices
-          const p1x = x(minX);
-          const p1y = y(minY);
-          const p2x = x(maxX);
-          const p2y = y(minY);
-          const p3x = x(maxX);
-          const p3y = y(maxY);
-          const p4x = x(minX);
-          const p4y = y(maxY);
+          const px1 = x(minX);
+          const py1 = y(minY);
+          const px2 = x(maxX);
+          const py2 = y(maxY);
 
-          boxSelectElement.vertices[0].set(p1x, p1y);
-          boxSelectElement.vertices[1].set(p2x, p2y);
-          boxSelectElement.vertices[2].set(p3x, p3y);
-          boxSelectElement.vertices[3].set(p4x, p4y);
+          const width = px2 - px1;
+          const height = py2 - py1;
+          const centerX = px1 + width / 2;
+          const centerY = py1 + height / 2;
+
+          boxSelectElement.translation.set(centerX, centerY);
+          (boxSelectElement as any).width = width;
+          (boxSelectElement as any).height = height;
 
           two!.update();
         } else if (isDown && currentElem) {
@@ -1271,18 +1269,8 @@
 
             if (boxSelectElement) boxSelectElement.remove();
 
-            // Create a path for the box
-            boxSelectElement = two!.makePath(
-              x(inchX),
-              y(inchY),
-              x(inchX),
-              y(inchY),
-              x(inchX),
-              y(inchY),
-              x(inchX),
-              y(inchY),
-              true as any,
-            );
+            // Create a rectangle for the box
+            boxSelectElement = new Two.Rectangle(x(inchX), y(inchY), 0, 0);
             boxSelectElement.fill = "rgba(59, 130, 246, 0.2)"; // blue-500 with opacity
             boxSelectElement.stroke = "#3b82f6";
             boxSelectElement.linewidth = 1;

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -218,10 +218,36 @@
   ) {
     if (!line.eventMarkers) return;
     line.eventMarkers.forEach((em: any, eIdx: number) => {
-      if (em.type === "pose" && em.poseX !== undefined && em.poseY !== undefined) {
+      if (
+        em.type === "pose" &&
+        em.poseX !== undefined &&
+        em.poseY !== undefined
+      ) {
         if (isPointInBox(em.poseX, em.poseY, minX, maxX, minY, maxY)) {
           newSelections.push(`event-${lIdx}-${eIdx}`);
         }
+      }
+    });
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function getLinePoints(
+    line: any,
+    lIdx: number,
+    minX: number,
+    maxX: number,
+    minY: number,
+    maxY: number,
+    newSelections: string[],
+  ) {
+    if (
+      isPointInBox(line.endPoint.x, line.endPoint.y, minX, maxX, minY, maxY)
+    ) {
+      newSelections.push(`point-${lIdx + 1}-0`);
+    }
+    line.controlPoints.forEach((cp: any, cpIdx: number) => {
+      if (isPointInBox(cp.x, cp.y, minX, maxX, minY, maxY)) {
+        newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
       }
     });
   }
@@ -234,15 +260,16 @@
     newSelections: string[],
   ) {
     lines.forEach((line, lIdx) => {
-      if (isPointInBox(line.endPoint.x, line.endPoint.y, minX, maxX, minY, maxY)) {
-        newSelections.push(`point-${lIdx + 1}-0`);
-      }
-      line.controlPoints.forEach((cp, cpIdx) => {
-        if (isPointInBox(cp.x, cp.y, minX, maxX, minY, maxY)) {
-          newSelections.push(`point-${lIdx + 1}-${cpIdx + 1}`);
-        }
-      });
-      checkEventMarkerSelections(line, lIdx, minX, maxX, minY, maxY, newSelections);
+      getLinePoints(line, lIdx, minX, maxX, minY, maxY, newSelections);
+      checkEventMarkerSelections(
+        line,
+        lIdx,
+        minX,
+        maxX,
+        minY,
+        maxY,
+        newSelections,
+      );
     });
   }
 

--- a/src/lib/components/dialogs/OptimizationDialog.svelte
+++ b/src/lib/components/dialogs/OptimizationDialog.svelte
@@ -390,16 +390,19 @@
         <div
           class="mt-2 rounded-md bg-yellow-50 border-l-4 border-yellow-400 p-3 text-sm text-yellow-800"
         >
-          <TriangleWarningIcon className="size-5 inline-block mr-2" /> <strong>{optimizationError}</strong> The path's structure is currently
-          invalid.
+          <TriangleWarningIcon className="size-5 inline-block mr-2" />
+          <strong>{optimizationError}</strong> The path's structure is currently invalid.
         </div>
       {:else if optimizationFailed}
-        <div class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-600 dark:text-red-400 text-sm flex items-start gap-2">
+        <div
+          class="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-red-600 dark:text-red-400 text-sm flex items-start gap-2"
+        >
           <TriangleWarningIcon className="size-5 shrink-0 mt-0.5" />
           <span>
-            <strong class="font-bold">Collision Avoidance Failed:</strong> The optimizer could not find a valid path because the
-            best candidates still collide with obstacles. Try creating an initial path
-            that avoids obstacles to guide the optimizer.
+            <strong class="font-bold">Collision Avoidance Failed:</strong> The optimizer
+            could not find a valid path because the best candidates still collide
+            with obstacles. Try creating an initial path that avoids obstacles to
+            guide the optimizer.
           </span>
         </div>
       {/if}

--- a/src/lib/components/dialogs/PathStatisticsDialog.svelte
+++ b/src/lib/components/dialogs/PathStatisticsDialog.svelte
@@ -941,10 +941,10 @@
                         At {formatTime(insight.startTime)}
                       {/if}
                       {#if insight.value}
-                      <div class="flex items-center gap-1.5">
-                        <DotIcon className="-mx-0.5 opacity-50" />
-                        <span>Max Value: {insight.value.toFixed(1)}</span>
-                      </div>
+                        <div class="flex items-center gap-1.5">
+                          <DotIcon className="-mx-0.5 opacity-50" />
+                          <span>Max Value: {insight.value.toFixed(1)}</span>
+                        </div>
                       {/if}
                     </div>
                   </div>

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(globalThis, { key: "Escape" });
+    await fireEvent.keyDown(window, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
+++ b/src/lib/components/dialogs/UnsavedChangesDialog.test.ts
@@ -48,7 +48,7 @@ describe("UnsavedChangesDialog", () => {
       onCancel,
     });
 
-    await fireEvent.keyDown(window, { key: "Escape" });
+    await fireEvent.keyDown(globalThis, { key: "Escape" });
     expect(onCancel).toHaveBeenCalled();
   });
 });

--- a/src/lib/components/settings/tabs/AboutSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/AboutSettingsTab.svelte
@@ -73,48 +73,62 @@
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline">Issues</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/releases"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline"
               >Releases</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/blob/main/README.md"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline">README</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/blob/main/CODE_OF_CONDUCT.md"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline"
               >Code of Conduct</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/blob/main/CONTRIBUTING.md"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline"
               >Contributing</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/blob/main/LICENSE"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline"
               >License</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://github.com/Mallen220/TurtleTracer/blob/main/SECURITY.md"
               target="_blank"
               class="text-blue-600 dark:text-blue-400 hover:underline"
               >Security</a
             >
-            <DotIcon className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0" />
+            <DotIcon
+              className="-mx-1 text-neutral-300 dark:text-neutral-600 shrink-0"
+            />
             <a
               href="https://discord.gg/chHSzS4ewF"
               target="_blank"


### PR DESCRIPTION
What: Users can now press Shift and drag across the empty field space to draw a selection box and select multiple items at once.
Why: Previously, multi-selecting points, obstacles, and events required individually shift-clicking every single element, which is tedious for large selections (like aligning or distributing many control points). A selection box provides a fast, standard, and highly expected UX pattern for bulk selection.
Behavior: Hold Shift and drag on any empty space on the field. A temporary visual rectangle tracks the drag. Releasing the mouse computes bounds and selects any path endpoints, control points, obstacle vertices, or event markers enclosed within, adding them to the existing multi-selection. Standard drag without Shift is preserved for panning.
Verification: Covered by ensuring test compatibility, formatting, and build success.

---
*PR created automatically by Jules for task [14462401773106392871](https://jules.google.com/task/14462401773106392871) started by @Mallen220*