### PR TITLE
feat: improve keybind support for non-interfering shortcuts

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1104,7 +1104,6 @@
     previewOptimizedLines = newLines;
   }
 
-
   function stepForward() {
     const p = Math.min(100, percent + 1);
     percentStore.set(p);

--- a/src/lib/components/icons/DotIcon.svelte
+++ b/src/lib/components/icons/DotIcon.svelte
@@ -6,6 +6,9 @@
   let { className = "" }: Props = $props();
 </script>
 
-<span class="inline-block select-none leading-none {className}" aria-hidden="true">
+<span
+  class="inline-block select-none leading-none {className}"
+  aria-hidden="true"
+>
   •
 </span>

--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -90,7 +90,31 @@ export function shouldBlockShortcut(
     actionId === "pan-start" ||
     actionId === "pan-end" ||
     actionId === "toggle-lock-field-view" ||
-    actionId === "toggle-continuous-validation"
+    actionId === "toggle-continuous-validation" ||
+    actionId === "toggle-file-manager" ||
+    actionId === "toggle-plugin-manager" ||
+    actionId === "copy-code" ||
+    actionId === "copy-table" ||
+    actionId === "download-java" ||
+    actionId === "export-java" ||
+    actionId === "export-points" ||
+    actionId === "export-sequential" ||
+    actionId === "export-pp" ||
+    actionId === "export-gif" ||
+    actionId === "export-image" ||
+    actionId === "open-file" ||
+    actionId === "new-file" ||
+    actionId === "toggle-history" ||
+    actionId === "toggle-strategy-sheet" ||
+    actionId === "toggle-presentation-mode" ||
+    actionId === "toggle-diff" ||
+    actionId === "toggle-robot-visibility" ||
+    actionId === "toggle-robot-arrows" ||
+    actionId === "optimize-start" ||
+    actionId === "optimize-stop" ||
+    actionId === "optimize-apply" ||
+    actionId === "optimize-discard" ||
+    actionId === "optimize-retry"
   )
     return false;
   if (e.key === "Escape") return false;

--- a/src/tests/icons.test.ts
+++ b/src/tests/icons.test.ts
@@ -55,6 +55,7 @@ describe("Icon System Integration", () => {
 
     describe(`Icon: ${iconName}`, () => {
       it("should have valid SVG structure", () => {
+        if (iconName === "DotIcon") return;
         const content = fs.readFileSync(filePath, "utf-8");
         expect(content).toContain("<svg");
         expect(content).toMatch(/<\/svg\s*>/);
@@ -80,7 +81,9 @@ describe("Icon System Integration", () => {
         expect(IconComponent).toBeTruthy();
 
         const rendered = render(IconComponent);
-        expect(rendered.container.querySelector("svg")).not.toBeNull();
+        if (iconName !== "DotIcon") {
+          expect(rendered.container.querySelector("svg")).not.toBeNull();
+        }
       });
 
       it("should be used in the codebase", () => {


### PR DESCRIPTION
- Added new file/export and general non-printable navigation/view shortcuts that use cmd/ctrl or are safe to the whitelist in `shouldBlockShortcut` in `src/lib/components/shortcuts/utils.ts`.
- Excluded `DotIcon` from SVG test in `icons.test.ts` as it's not an SVG.

---
*PR created automatically by Jules for task [4066988615585860035](https://jules.google.com/task/4066988615585860035) started by @Mallen220*