### PR TITLE
✨ Feature: Better Keybind Support

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -66,7 +66,6 @@ export function shouldBlockShortcut(
   // Whitelist specific actions that should work even when input is focused
   if (
     actionId === "toggle-command-palette" ||
-    actionId === "show-help" ||
     actionId === "cycle-tabs-next" ||
     actionId === "cycle-tabs-prev" ||
     actionId === "select-code-tab" ||
@@ -75,8 +74,6 @@ export function shouldBlockShortcut(
     actionId === "select-table-tab" ||
     actionId === "save-project" ||
     actionId === "save-file-as" ||
-    actionId === "undo" ||
-    actionId === "redo" ||
     actionId === "open-settings" ||
     actionId === "toggle-sidebar" ||
     actionId === "zoom-in" ||
@@ -87,10 +84,22 @@ export function shouldBlockShortcut(
     actionId === "pan-view-down" ||
     actionId === "pan-view-left" ||
     actionId === "pan-view-right" ||
-    actionId === "pan-start" ||
-    actionId === "pan-end" ||
     actionId === "toggle-lock-field-view" ||
-    actionId === "toggle-continuous-validation"
+    actionId === "toggle-continuous-validation" ||
+    actionId === "new-file" ||
+    actionId === "open-file" ||
+    actionId === "export-java" ||
+    actionId === "export-points" ||
+    actionId === "export-sequential" ||
+    actionId === "export-pp" ||
+    actionId === "export-gif" ||
+    actionId === "export-image" ||
+    actionId === "download-java" ||
+    actionId === "copy-code" ||
+    actionId === "copy-table" ||
+    actionId === "docs" ||
+    actionId === "focus-name" ||
+    actionId === "confirm-dialog"
   )
     return false;
   if (e.key === "Escape") return false;

--- a/src/tests/lib/components/shortcuts/utils.test.ts
+++ b/src/tests/lib/components/shortcuts/utils.test.ts
@@ -65,7 +65,7 @@ describe("shortcuts utils", () => {
       expect(!!shouldBlockShortcut({} as KeyboardEvent, "save-project")).toBe(
         false,
       );
-      expect(!!shouldBlockShortcut({} as KeyboardEvent, "undo")).toBe(false);
+
 
       const viewActions = [
         "zoom-in",
@@ -75,8 +75,8 @@ describe("shortcuts utils", () => {
         "pan-view-down",
         "pan-view-left",
         "pan-view-right",
-        "pan-start",
-        "pan-end",
+
+
       ];
       viewActions.forEach((action) => {
         expect(!!shouldBlockShortcut({} as KeyboardEvent, action)).toBe(false);


### PR DESCRIPTION
✨ Feature: Better Keybind Support

What:
- Removed `show-help`, `undo`, `redo`, `pan-start`, and `pan-end` from the `shouldBlockShortcut` whitelist so native text editing shortcuts (like `Cmd+Z` and `Home`/`End`) work properly when an input field is focused.
- Added explicitly safe non-conflicting modifiers (like `new-file`, `export-java`, `docs`) to the `shouldBlockShortcut` whitelist so they work properly even when an input field is focused.
- Updated `utils.test.ts` to reflect these whitelist changes.

Why:
- Improves accessibility and UI/UX by fixing keybind collisions with native text input bindings.

Behavior:
- When a user is typing inside an input field, they can now safely type `?` or press `Home`/`End` without unintentionally panning the field or showing the help menu.
- When an input field is focused, the user can still use core shortcut keys like Ctrl+N (new file), Ctrl+O (open file) and Ctrl+Shift+J (export Java) safely.

Verification:
- Run `npm run test`. All tests should pass.
- In the running app, click inside a text box and press `Home`, `End` or type `?`. Verify it affects the text input, rather than application state.

---
*PR created automatically by Jules for task [17700278400236781605](https://jules.google.com/task/17700278400236781605) started by @Mallen220*