### PR TITLE
chore: Refactor codebase to reduce clone duplication below threshold

### DIFF
--- a/src/tests/contextMenu.test.ts
+++ b/src/tests/contextMenu.test.ts
@@ -1,21 +1,13 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 import ContextMenu from "../lib/components/tools/ContextMenu.svelte";
 import { tick } from "svelte";
+import { setupUIViewport } from "./testUtils";
 
 describe("ContextMenu", () => {
   beforeEach(() => {
-    Object.defineProperty(globalThis, "innerWidth", {
-      writable: true,
-      configurable: true,
-      value: 1000,
-    });
-    Object.defineProperty(globalThis, "innerHeight", {
-      writable: true,
-      configurable: true,
-      value: 1000,
-    });
+    setupUIViewport();
   });
 
   it("updates items correctly", async () => {
@@ -44,39 +36,4 @@ describe("ContextMenu", () => {
       (props: any) => render(ContextMenu as any, props),
     );
   });
-
-  const menuNode = screen.getByRole("menu");
-  menuNode.getBoundingClientRect = vi.fn(
-    () =>
-      ({
-        width: 200,
-        height: 200,
-        top: 0,
-        left: 0,
-        right: 200,
-        bottom: 200,
-        x: 0,
-        y: 0,
-        toJSON: () => {},
-      }) as any,
-  );
-
-  // Let effect run
-  await tick();
-  await tick();
-
-  expect(menuNode.style.left).toBe("700px");
-  expect(menuNode.style.top).toBe("700px");
-
-  await rerender({
-    x: 100,
-    y: 100,
-    items: [{ label: "Item 1 Updated" }],
-  });
-
-  await tick();
-  await tick();
-
-  expect(menuNode.style.left).toBe("100px");
-  expect(menuNode.style.top).toBe("100px");
 });

--- a/src/tests/contextMenu.test.ts
+++ b/src/tests/contextMenu.test.ts
@@ -34,45 +34,49 @@ describe("ContextMenu", () => {
   });
 
   it("updates position correctly when going off screen", async () => {
-    const { rerender } = render(ContextMenu as any, {
-      x: 900,
-      y: 900,
-      items: [{ label: "Item 1" }],
-    });
-
-    const menuNode = screen.getByRole("menu");
-    menuNode.getBoundingClientRect = vi.fn(
-      () =>
-        ({
-          width: 200,
-          height: 200,
-          top: 0,
-          left: 0,
-          right: 200,
-          bottom: 200,
-          x: 0,
-          y: 0,
-          toJSON: () => {},
-        }) as any,
+    const { testMenuOffScreenPositioning } = await import("./testUtils");
+    await testMenuOffScreenPositioning(
+      { x: 900, y: 900, items: [{ label: "Item 1" }] },
+      { x: 100, y: 100, items: [{ label: "Item 1 Updated" }] },
+      tick,
+      screen,
+      expect,
+      (props: any) => render(ContextMenu as any, props),
     );
-
-    // Let effect run
-    await tick();
-    await tick();
-
-    expect(menuNode.style.left).toBe("700px");
-    expect(menuNode.style.top).toBe("700px");
-
-    await rerender({
-      x: 100,
-      y: 100,
-      items: [{ label: "Item 1 Updated" }],
-    });
-
-    await tick();
-    await tick();
-
-    expect(menuNode.style.left).toBe("100px");
-    expect(menuNode.style.top).toBe("100px");
   });
+
+  const menuNode = screen.getByRole("menu");
+  menuNode.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        width: 200,
+        height: 200,
+        top: 0,
+        left: 0,
+        right: 200,
+        bottom: 200,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as any,
+  );
+
+  // Let effect run
+  await tick();
+  await tick();
+
+  expect(menuNode.style.left).toBe("700px");
+  expect(menuNode.style.top).toBe("700px");
+
+  await rerender({
+    x: 100,
+    y: 100,
+    items: [{ label: "Item 1 Updated" }],
+  });
+
+  await tick();
+  await tick();
+
+  expect(menuNode.style.left).toBe("100px");
+  expect(menuNode.style.top).toBe("100px");
 });

--- a/src/tests/fileContextMenu.test.ts
+++ b/src/tests/fileContextMenu.test.ts
@@ -1,21 +1,13 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/svelte";
 import FileContextMenu from "../lib/components/filemanager/FileContextMenu.svelte";
 import { tick } from "svelte";
+import { setupUIViewport } from "./testUtils";
 
 describe("FileContextMenu", () => {
   beforeEach(() => {
-    Object.defineProperty(globalThis, "innerWidth", {
-      writable: true,
-      configurable: true,
-      value: 1000,
-    });
-    Object.defineProperty(globalThis, "innerHeight", {
-      writable: true,
-      configurable: true,
-      value: 1000,
-    });
+    setupUIViewport();
   });
 
   it("updates fileName correctly", async () => {
@@ -49,40 +41,4 @@ describe("FileContextMenu", () => {
       (props: any) => render(FileContextMenu as any, props),
     );
   });
-
-  const menuNode = screen.getByRole("menu");
-  menuNode.getBoundingClientRect = vi.fn(
-    () =>
-      ({
-        width: 200,
-        height: 200,
-        top: 0,
-        left: 0,
-        right: 200,
-        bottom: 200,
-        x: 0,
-        y: 0,
-        toJSON: () => {},
-      }) as any,
-  );
-
-  // Let effect run
-  await tick();
-  await tick();
-
-  expect(menuNode.style.left).toBe("700px");
-  expect(menuNode.style.top).toBe("700px");
-
-  await rerender({
-    x: 100,
-    y: 100,
-    fileName: "file1.txt",
-    isDirectory: false,
-  });
-
-  await tick();
-  await tick();
-
-  expect(menuNode.style.left).toBe("100px");
-  expect(menuNode.style.top).toBe("100px");
 });

--- a/src/tests/fileContextMenu.test.ts
+++ b/src/tests/fileContextMenu.test.ts
@@ -39,47 +39,50 @@ describe("FileContextMenu", () => {
   });
 
   it("updates position correctly when going off screen", async () => {
-    const { rerender } = render(FileContextMenu as any, {
-      x: 900,
-      y: 900,
-      fileName: "file1.txt",
-      isDirectory: false,
-    });
-
-    const menuNode = screen.getByRole("menu");
-    menuNode.getBoundingClientRect = vi.fn(
-      () =>
-        ({
-          width: 200,
-          height: 200,
-          top: 0,
-          left: 0,
-          right: 200,
-          bottom: 200,
-          x: 0,
-          y: 0,
-          toJSON: () => {},
-        }) as any,
+    const { testMenuOffScreenPositioning } = await import("./testUtils");
+    await testMenuOffScreenPositioning(
+      { x: 900, y: 900, fileName: "file1.txt", isDirectory: false },
+      { x: 100, y: 100, fileName: "file1.txt", isDirectory: false },
+      tick,
+      screen,
+      expect,
+      (props: any) => render(FileContextMenu as any, props),
     );
-
-    // Let effect run
-    await tick();
-    await tick();
-
-    expect(menuNode.style.left).toBe("700px");
-    expect(menuNode.style.top).toBe("700px");
-
-    await rerender({
-      x: 100,
-      y: 100,
-      fileName: "file1.txt",
-      isDirectory: false,
-    });
-
-    await tick();
-    await tick();
-
-    expect(menuNode.style.left).toBe("100px");
-    expect(menuNode.style.top).toBe("100px");
   });
+
+  const menuNode = screen.getByRole("menu");
+  menuNode.getBoundingClientRect = vi.fn(
+    () =>
+      ({
+        width: 200,
+        height: 200,
+        top: 0,
+        left: 0,
+        right: 200,
+        bottom: 200,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      }) as any,
+  );
+
+  // Let effect run
+  await tick();
+  await tick();
+
+  expect(menuNode.style.left).toBe("700px");
+  expect(menuNode.style.top).toBe("700px");
+
+  await rerender({
+    x: 100,
+    y: 100,
+    fileName: "file1.txt",
+    isDirectory: false,
+  });
+
+  await tick();
+  await tick();
+
+  expect(menuNode.style.left).toBe("100px");
+  expect(menuNode.style.top).toBe("100px");
 });

--- a/src/tests/testUtils.ts
+++ b/src/tests/testUtils.ts
@@ -29,3 +29,50 @@ export const isPathItem = (s: SequenceItem): s is SequencePathItem =>
 
 export const isMacroItem = (s: SequenceItem): s is SequenceMacroItem =>
   s.kind === macroKind();
+
+export const setupUIViewport = () => {
+  Object.defineProperty(globalThis, "innerWidth", {
+    writable: true,
+    configurable: true,
+    value: 1000,
+  });
+  Object.defineProperty(globalThis, "innerHeight", {
+    writable: true,
+    configurable: true,
+    value: 1000,
+  });
+};
+
+export const testMenuOffScreenPositioning = async (
+  initialProps: any,
+  updatedProps: any,
+  tick: any,
+  screen: any,
+  expect: any,
+  renderComponent: any,
+) => {
+  const { rerender } = renderComponent(initialProps);
+  const menuNodes = screen.getAllByRole("menu");
+  const menuNode = menuNodes[menuNodes.length - 1]; // get the latest rendered menu
+  menuNode.getBoundingClientRect = () =>
+    ({
+      width: 200,
+      height: 200,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 200,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    }) as any;
+  await tick();
+  await tick();
+  expect(menuNode.style.left).toBe("700px");
+  expect(menuNode.style.top).toBe("700px");
+  await rerender(updatedProps);
+  await tick();
+  await tick();
+  expect(menuNode.style.left).toBe("100px");
+  expect(menuNode.style.top).toBe("100px");
+};


### PR DESCRIPTION
This commit fixes several code clones identified by jscpd during the 'npm run test:duplication' routine. The goal is to bring the duplication rate under 0.5%.

Extracted repeating logic in test files like `contextMenu.test.ts` and `fileContextMenu.test.ts`. Unified array variables in `geometry.test.ts`. Reduced copy-paste within `pluginManager.ts` by pulling static constants to module level. Brought the total duplicate clones count down significantly.

---
*PR created automatically by Jules for task [891284110449241913](https://jules.google.com/task/891284110449241913) started by @Mallen220*