### PR TITLE
Feature: Enhance Accessibility and Keybind Visibility

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1936,6 +1936,7 @@
             type="button"
             class="absolute inset-0 opacity-0 pointer-events-none"
             aria-label="Field workspace tutorial target"
+            title="Field workspace tutorial target"
             tabindex={$startTutorial ? 0 : -1}
           ></button>
           <SvelteComponent_1

--- a/src/lib/FileManager.svelte
+++ b/src/lib/FileManager.svelte
@@ -1203,6 +1203,7 @@
       class="absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-blue-500 z-50 transition-colors appearance-none bg-transparent"
       onmousedown={startResize}
       aria-label="Resize sidebar"
+      title="Resize sidebar"
     ></button>
 
     <!-- Header -->

--- a/src/lib/components/WaypointTable.svelte
+++ b/src/lib/components/WaypointTable.svelte
@@ -1317,7 +1317,9 @@
     </h3>
     <div class="flex items-center gap-2">
       <button
-        title={copyButtonText}
+        title={copyButtonText === "Copied!"
+          ? "Copied!"
+          : `Copy Table${getShortcutFromSettings(settings, "copy-table")}`}
         aria-label={copyButtonText}
         onclick={copyTableToClipboard}
         class="flex flex-row items-center gap-1 hover:bg-neutral-200 dark:hover:bg-neutral-800 px-2 py-1 rounded transition-colors text-neutral-600 dark:text-neutral-400 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"

--- a/src/lib/components/dialogs/SettingsItem.svelte
+++ b/src/lib/components/dialogs/SettingsItem.svelte
@@ -61,7 +61,7 @@
         <button
           type="button"
           class="p-1 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 dark:hover:text-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-          title="Reset to default"
+          title="Reset {label}"
           onclick={onReset}
           aria-label="Reset {label}"
         >
@@ -86,7 +86,7 @@
             <button
               type="button"
               class="p-1 rounded-md text-neutral-400 hover:text-neutral-600 hover:bg-neutral-100 dark:hover:text-neutral-200 dark:hover:bg-neutral-700 transition-colors flex-shrink-0"
-              title="Reset to default"
+              title="Reset {label}"
               onclick={onReset}
               aria-label="Reset {label}"
             >

--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -19,6 +19,7 @@
   import codeStyle from "svelte-highlight/styles/androidstudio";
   import { get } from "svelte/store";
   import { currentFilePath } from "../../../stores";
+  import { getShortcutFromSettings } from "../../../utils";
   import { diffLines } from "diff";
   import hljs from "highlight.js/lib/core";
   import java from "highlight.js/lib/languages/java";
@@ -416,7 +417,7 @@
     <button
       onclick={handleDownloadJava}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("purple")}`}
-      title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}`}
+      title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
       aria-label="Download generated file"
       disabled={!code}
       aria-disabled={!code}
@@ -432,7 +433,9 @@
     <button
       onclick={handleCopy}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("blue")} ${isGenerating || !code ? "opacity-50 cursor-not-allowed" : ""}`}
-      title={copyButtonText === "Copied!" ? "Copied!" : "Copy Code"}
+      title={copyButtonText === "Copied!"
+        ? "Copied!"
+        : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
       disabled={isGenerating || !code}
       aria-disabled={isGenerating || !code}
       aria-label="Copy generated code"


### PR DESCRIPTION
What:
- Added missing `title` attributes matching their `aria-label`s for UI buttons in `App.svelte` and `FileManager.svelte`.
- Fixed tooltip mismatch in `SettingsItem.svelte`.
- Refactored `CodeTab.svelte` and `WaypointTable.svelte` to explicitly display global keyboard shortcuts in their action button tooltips using `getShortcutFromSettings`.

Why:
Improves accessibility for screen readers and UI/UX discoverability of keybinds.

Behavior:
Hovering over the "Download" or "Copy" buttons now displays the shortcut keys (e.g., `Cmd/Ctrl+J`). Field workspace targets and resize handles no longer flag accessibility tests.

Verification:
Tested with Svelte UI components and `npm run test` and `npm run check`.

---
*PR created automatically by Jules for task [2332702560241218557](https://jules.google.com/task/2332702560241218557) started by @Mallen220*