### PR TITLE
✨ Feature: Unblock Undo/Redo Shortcuts

### DIFF
--- a/src/lib/components/shortcuts/utils.ts
+++ b/src/lib/components/shortcuts/utils.ts
@@ -99,7 +99,11 @@ export function shouldBlockShortcut(
     actionId === "copy-table" ||
     actionId === "docs" ||
     actionId === "focus-name" ||
-    actionId === "confirm-dialog"
+    actionId === "confirm-dialog" ||
+    // Allow Undo/Redo even when text inputs are focused so users can undo accidental text deletions
+    // or sequence changes without losing form focus.
+    actionId === "undo" ||
+    actionId === "redo"
   )
     return false;
   if (e.key === "Escape") return false;


### PR DESCRIPTION
### What
Whitelists the "undo" and "redo" global keyboard shortcuts (e.g. Cmd+Z/Ctrl+Z) so they are no longer blocked when the user has focus on a text input or form field. 

### Why
Previously, if a user made a mistake typing in a field (e.g. accidentally deleting text) and pressed Undo, the shortcut was blocked. This forced them to click outside the input, triggering a save/blur, and *then* press Undo, which led to frustrating and unpredictable state changes. This improves the overall editing experience.

### Behavior
When a user is actively typing in a path name, point coordinate, or other text input and presses Cmd+Z (or their configured undo bind), the undo action will now trigger properly.

### Verification
- Run `npm run dev`
- Select any text input (e.g. the path name on the left sidebar or a coordinate box).
- Type some text, then press `Cmd+Z` (or `Ctrl+Z` on Windows).
- Observe that the undo action fires correctly rather than being blocked.

---
*PR created automatically by Jules for task [9681256080435900267](https://jules.google.com/task/9681256080435900267) started by @Mallen220*