### PR TITLE
✨ Feature: Add keybinding tooltips to code export buttons

### DIFF
--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -19,6 +19,7 @@
   import codeStyle from "svelte-highlight/styles/androidstudio";
   import { get } from "svelte/store";
   import { currentFilePath } from "../../../stores";
+  import { getShortcutFromSettings } from "../../../utils";
   import { diffLines } from "diff";
   import hljs from "highlight.js/lib/core";
   import java from "highlight.js/lib/languages/java";
@@ -416,7 +417,7 @@
     <button
       onclick={handleDownloadJava}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("purple")}`}
-      title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}`}
+      title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
       aria-label="Download generated file"
       disabled={!code}
       aria-disabled={!code}
@@ -432,7 +433,9 @@
     <button
       onclick={handleCopy}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("blue")} ${isGenerating || !code ? "opacity-50 cursor-not-allowed" : ""}`}
-      title={copyButtonText === "Copied!" ? "Copied!" : "Copy Code"}
+      title={copyButtonText === "Copied!"
+        ? "Copied!"
+        : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
       disabled={isGenerating || !code}
       aria-disabled={isGenerating || !code}
       aria-label="Copy generated code"


### PR DESCRIPTION
**What**
Added keyboard shortcut hints to the "Download Java" and "Copy Code" buttons in `src/lib/components/tabs/CodeTab.svelte`.

**Why**
To improve the UI/UX and accessibility of the program by allowing users to more easily discover the available global keyboard shortcuts for code exporting tasks.

**Behavior**
When a user hovers over the "Download" or "Copy Code" buttons in the code preview tab, the tooltip text will now append the correct keyboard shortcut currently mapped in the settings (e.g., `Download as .java(cmd+j)`).

**Verification**
1. Build or run the application.
2. Navigate to the code export tab (alt+4).
3. Hover over the "Download Java" or "Copy Code" buttons and ensure the tooltip displays the currently bound shortcut alongside the label.

---
*PR created automatically by Jules for task [17126778344986283561](https://jules.google.com/task/17126778344986283561) started by @Mallen220*