### PR TITLE
feature: Reduce test code duplication

### DIFF
--- a/src/tests/PathStatisticsDialog.test.ts
+++ b/src/tests/PathStatisticsDialog.test.ts
@@ -13,6 +13,18 @@ describe("PathStatisticsDialog", () => {
   let defaultSequence: SequenceItem[];
   let defaultSettings: Settings;
 
+  const renderDialog = (overrides = {}) => {
+    return render(PathStatisticsDialog, {
+      startPoint: defaultStartPoint,
+      lines: defaultLines,
+      sequence: defaultSequence,
+      settings: defaultSettings,
+      isOpen: true,
+      onClose: vi.fn(),
+      ...overrides,
+    });
+  };
+
   beforeEach(() => {
     // Ensure core actions registered for stable test kinds
     actionRegistry.reset();
@@ -44,28 +56,14 @@ describe("PathStatisticsDialog", () => {
   });
 
   it("renders summary stats correctly", () => {
-    const { getByText, getAllByText } = render(PathStatisticsDialog, {
-      startPoint: defaultStartPoint,
-      lines: defaultLines,
-      sequence: defaultSequence,
-      settings: defaultSettings,
-      isOpen: true,
-      onClose: vi.fn(),
-    });
+    const { getByText, getAllByText } = renderDialog();
 
     expect(getByText("Path Statistics")).toBeTruthy();
     expect(getAllByText("Total Time").length).toBeGreaterThan(0);
   });
 
   it("switches to graphs tab", async () => {
-    const { getByText, getAllByText } = render(PathStatisticsDialog, {
-      startPoint: defaultStartPoint,
-      lines: defaultLines,
-      sequence: defaultSequence,
-      settings: defaultSettings,
-      isOpen: true,
-      onClose: vi.fn(),
-    });
+    const { getByText, getAllByText } = renderDialog();
 
     const graphsTab = getByText("Graphs");
     expect(graphsTab).toBeTruthy();
@@ -77,13 +75,8 @@ describe("PathStatisticsDialog", () => {
   });
 
   it("shows acceleration graphs and insights tab", async () => {
-    const { getByText, getAllByText } = render(PathStatisticsDialog, {
-      startPoint: defaultStartPoint,
-      lines: defaultLines,
-      sequence: defaultSequence,
-      settings: { ...defaultSettings, kFriction: 0.5 },
-      isOpen: true,
-      onClose: vi.fn(),
+    const { getByText, getAllByText } = renderDialog({
+      settings: { ...defaultSettings, kFriction: 0.5 }
     });
 
     // Check Graphs

--- a/src/tests/fileSystemAdapter.test.ts
+++ b/src/tests/fileSystemAdapter.test.ts
@@ -146,45 +146,6 @@ describe("Directory Settings & File Handlers", () => {
   });
 
   describe("fileHandlers", () => {
-    describe("loadRecentFile", () => {
-      it("should alert if electronAPI is missing", async () => {
-        delete (globalThis as any).electronAPI;
-        const { loadRecentFile } = await import("../utils/fileHandlers");
-        const alertMock = vi
-          .spyOn(globalThis, "alert")
-          .mockImplementation(() => {});
-
-        await loadRecentFile("test.pp");
-        expect(alertMock).toHaveBeenCalledWith(
-          "Cannot load files in this environment",
-        );
-      });
-
-      it("should prompt to remove if file does not exist", async () => {
-        mockElectronAPI.fileExists.mockResolvedValue(false);
-        const { loadRecentFile } = await import("../utils/fileHandlers");
-        const confirmMock = vi
-          .spyOn(globalThis, "confirm")
-          .mockReturnValue(true);
-
-        await loadRecentFile("test.pp");
-
-        expect(confirmMock).toHaveBeenCalled();
-      });
-
-      it("should load file if it exists", async () => {
-        mockElectronAPI.fileExists.mockResolvedValue(true);
-        mockElectronAPI.readFile.mockResolvedValue(
-          '{"startPoint": { "x":0, "y":0 }}',
-        );
-        const { loadRecentFile } = await import("../utils/fileHandlers");
-
-        await loadRecentFile("test.pp");
-
-        expect(mockElectronAPI.readFile).toHaveBeenCalledWith("test.pp");
-      });
-    });
-
     describe("handleExternalFileOpen", () => {
       it("should copy file if not in saved directory and user confirms", async () => {
         mockElectronAPI.readFile.mockResolvedValue("{}");

--- a/src/tests/math.test.ts
+++ b/src/tests/math.test.ts
@@ -169,83 +169,92 @@ describe("Math Utils", () => {
     });
   });
 
+  const createTestLine = (heading, extras = {}) => ({
+    endPoint: { x: 10, y: 10, heading, ...extras },
+  });
+
+  const testUndefinedHandling = (fn) => {
+    const p = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
+    expect(fn(undefined, p)).toBe(0);
+    expect(
+      fn(
+        { endPoint: undefined as unknown as Point } as Line,
+        p,
+      ),
+    ).toBe(0);
+  };
+
+  const testTangentialHeading = (fn) => {
+    const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
+    const line = createTestLine("tangential", { reverse: false }) as Line;
+    expect(fn(line, prev)).toBe(45);
+  };
+
+  const testReversedTangentialHeading = (fn) => {
+    const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
+    const line = createTestLine("tangential", { reverse: true }) as Line;
+    expect(fn(line, prev)).toBe(-135);
+  };
+
+  const testPiecewiseLinearHeading = (fn) => {
+    const p1 = { x: 0, y: 0 } as Point;
+    const globalOverride = {
+      id: "root-line",
+      globalHeading: "piecewise",
+      globalSegments: [
+        {
+          tStart: 0,
+          tEnd: 1,
+          heading: "linear",
+          startDeg: 0,
+          endDeg: 180,
+        },
+      ],
+    } as any;
+
+    const res = fn(
+      { id: "line-2", endPoint: {} } as any,
+      p1,
+      globalOverride,
+      20, // totalChainDistance
+      10, // distanceBefore
+    );
+
+    expect(res).toBe(90);
+  };
+
+
+
   describe("getLineStartHeading", () => {
     it("returns 0 if line or endpoint is undefined", () => {
-      const p = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      expect(getLineStartHeading(undefined, p)).toBe(0);
-      expect(
-        getLineStartHeading(
-          { endPoint: undefined as unknown as Point } as Line,
-          p,
-        ),
-      ).toBe(0);
+      testUndefinedHandling(getLineStartHeading);
     });
 
     it("returns degrees for constant heading", () => {
       const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "constant",
-          degrees: 45,
-        } as Point,
-      } as Line;
+      const line = createTestLine("constant", { degrees: 45 }) as Line;
       expect(getLineStartHeading(line, prev)).toBe(45);
     });
 
     it("returns startDeg for linear heading", () => {
       const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "linear",
-          startDeg: 30,
-          endDeg: 60,
-        } as Point,
-      } as Line;
+      const line = createTestLine("linear", { startDeg: 30, endDeg: 60 }) as Line;
       expect(getLineStartHeading(line, prev)).toBe(30);
     });
 
     it("returns tangent angle for tangential heading", () => {
-      const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
-      } as Line;
-      // Angle from (0,0) to (10,10) is 45 degrees
-      expect(getLineStartHeading(line, prev)).toBe(45);
+      testTangentialHeading(getLineStartHeading);
     });
 
     it("returns reversed tangent angle for tangential heading with reverse=true", () => {
-      const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: true,
-        } as Point,
-      } as Line;
-      // Angle from (0,0) to (10,10) is 45 degrees, +180 = 225 -> -135
-      expect(getLineStartHeading(line, prev)).toBe(-135);
+      testReversedTangentialHeading(getLineStartHeading);
     });
 
     it("uses control points for tangential heading", () => {
       const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
       const line = {
         controlPoints: [{ x: 5, y: 0 }],
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
+        ...createTestLine("tangential", { reverse: false })
       } as Line;
       // Angle from (0,0) to first CP (5,0) is 0 degrees
       expect(getLineStartHeading(line, prev)).toBe(0);
@@ -258,42 +267,14 @@ describe("Math Utils", () => {
           { x: 0, y: 0 }, // Overlaps with prev
           { x: 5, y: 5 },
         ],
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
+        ...createTestLine("tangential", { reverse: false })
       } as Line;
       // Should skip (0,0) and use (5,5), angle 45
       expect(getLineStartHeading(line, prev)).toBe(45);
     });
 
     it("interpolates piecewise linear headings across a global chain", () => {
-      const p1 = { x: 0, y: 0 } as Point;
-      const globalOverride = {
-        id: "root-line",
-        globalHeading: "piecewise",
-        globalSegments: [
-          {
-            tStart: 0,
-            tEnd: 1,
-            heading: "linear",
-            startDeg: 0,
-            endDeg: 180,
-          },
-        ],
-      } as any;
-
-      const res = getLineStartHeading(
-        { id: "line-2", endPoint: {} } as any,
-        p1,
-        globalOverride,
-        20, // totalChainDistance
-        10, // distanceBefore
-      );
-
-      expect(res).toBe(90);
+      testPiecewiseLinearHeading(getLineStartHeading);
     });
   });
 
@@ -375,68 +356,27 @@ describe("Math Utils", () => {
 
   describe("getLineEndHeading", () => {
     it("returns 0 if line or endpoint is undefined", () => {
-      const p = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      expect(getLineEndHeading(undefined, p)).toBe(0);
-      expect(
-        getLineEndHeading(
-          { endPoint: undefined as unknown as Point } as Line,
-          p,
-        ),
-      ).toBe(0);
+      testUndefinedHandling(getLineEndHeading);
     });
 
     it("returns degrees for constant heading", () => {
       const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "constant",
-          degrees: 90,
-        } as Point,
-      } as Line;
+      const line = createTestLine("constant", { degrees: 90 }) as Line;
       expect(getLineEndHeading(line, prev)).toBe(90);
     });
 
     it("returns endDeg for linear heading", () => {
       const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "linear",
-          startDeg: 30,
-          endDeg: 60,
-        } as Point,
-      } as Line;
+      const line = createTestLine("linear", { startDeg: 30, endDeg: 60 }) as Line;
       expect(getLineEndHeading(line, prev)).toBe(60);
     });
 
     it("returns tangent angle for tangential heading", () => {
-      const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
-      } as Line;
-      // Angle from (0,0) to (10,10) is 45 degrees
-      expect(getLineEndHeading(line, prev)).toBe(45);
+      testTangentialHeading(getLineEndHeading);
     });
 
     it("returns reversed tangent angle for tangential heading with reverse=true", () => {
-      const prev = { x: 0, y: 0, heading: "constant", degrees: 0 } as Point;
-      const line = {
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: true,
-        } as Point,
-      } as Line;
-      expect(getLineEndHeading(line, prev)).toBe(-135);
+      testReversedTangentialHeading(getLineEndHeading);
     });
 
     it("uses last control point for tangential heading", () => {
@@ -445,12 +385,7 @@ describe("Math Utils", () => {
         controlPoints: [
           { x: 5, y: 10 }, // Last CP is (5,10)
         ],
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
+        ...createTestLine("tangential", { reverse: false })
       } as Line;
       // Angle from CP (5,10) to End (10,10) is 0 degrees
       expect(getLineEndHeading(line, prev)).toBe(0);
@@ -463,12 +398,7 @@ describe("Math Utils", () => {
           { x: 5, y: 5 },
           { x: 10, y: 10 }, // Overlaps with end
         ],
-        endPoint: {
-          x: 10,
-          y: 10,
-          heading: "tangential",
-          reverse: false,
-        } as Point,
+        ...createTestLine("tangential", { reverse: false })
       } as Line;
       // Should skip (10,10) and use (5,5) as prev point for tangent
       // Tangent from (5,5) to (10,10) is 45 degrees


### PR DESCRIPTION
This PR addresses code duplication specifically found within test files to improve maintainability.

**What:**
- Removed duplicate `loadRecentFile` test suite block from `src/tests/fileSystemAdapter.test.ts` since it already fully exists in `src/tests/fileHandlers.test.ts`.
- Extracted boilerplate rendering setup into a `renderDialog` helper in `src/tests/PathStatisticsDialog.test.ts`.
- Refactored `src/tests/math.test.ts` by introducing several helper functions (e.g., `createTestLine`, `testUndefinedHandling`, `testTangentialHeading`, `testReversedTangentialHeading`) that group similar test assertions and setup, significantly shrinking repetitive boilerplate code.

**Why:**
To reach the goal of < 0.5% duplication in the repository and improve test readability.

**Behavior:**
No runtime behavioral changes. Tests continue to pass as expected.

**Verification:**
Run `npm run test` to verify no logic was broken. Run `npm run test:duplication` and verify the percentage drops below 0.5%.

---
*PR created automatically by Jules for task [8277190457904086337](https://jules.google.com/task/8277190457904086337) started by @Mallen220*