### PR TITLE
Feature: Live Timeline Scrubbing Preview

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -80,6 +80,9 @@
     robotXYStore,
     robotHeadingStore,
     percentStore,
+    hoverPercentStore,
+    hoverRobotXYStore,
+    hoverRobotHeadingStore,
     playingStore,
     loopAnimationStore,
     playbackSpeedStore,
@@ -1299,6 +1302,7 @@
   let sequence = $derived($sequenceStore);
   let macros = $derived($macrosStore);
   let percent = $derived($percentStore);
+  let hoverPercent = $derived($hoverPercentStore);
   let playing = $derived($playingStore);
   let loopAnimation = $derived($loopAnimationStore);
   let playbackSpeed = $derived($playbackSpeedStore);
@@ -1511,6 +1515,34 @@
       // Tangential defaults to 0 if no lines
       robotHeadingStore.set(h);
       committedRobotState = null;
+    }
+  });
+
+  $effect(() => {
+    if (
+      hoverPercent !== null &&
+      timePrediction?.timeline &&
+      (lines.length > 0 || sequence.length > 0)
+    ) {
+      const globalTime = (hoverPercent / 100) * effectiveDuration;
+      let currentPercent = 0;
+      if (currentTotalTime > 0) {
+        currentPercent = (globalTime / currentTotalTime) * 100;
+        if (currentPercent > 100) currentPercent = 100;
+      }
+      const state = calculateRobotState(
+        currentPercent,
+        timePrediction.timeline,
+        lines,
+        startPoint,
+        IDENTITY_SCALE,
+        IDENTITY_SCALE,
+      );
+      hoverRobotXYStore.set({ x: state.x, y: state.y });
+      hoverRobotHeadingStore.set(state.heading);
+    } else {
+      hoverRobotXYStore.set(null);
+      hoverRobotHeadingStore.set(null);
     }
   });
   $effect(() => {

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -1,5 +1,9 @@
 <!-- Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0. -->
 <script lang="ts">
+  import {
+    hoverRobotXYStore,
+    hoverRobotHeadingStore,
+  } from "../../lib/projectStore";
   import { onMount, onDestroy } from "svelte";
   import { get } from "svelte/store";
   import Two from "two.js";
@@ -173,6 +177,8 @@
   let isDown = false;
   let isPanning = false;
   let isDrawing = false;
+  let hoverRobotXY = $derived($hoverRobotXYStore);
+  let hoverRobotHeading = $derived($hoverRobotHeadingStore);
 
   // Box Selection State
   let tooltipVisible = $state(false);
@@ -3037,6 +3043,54 @@
           style={`position: absolute; top: ${y(committedRobotState.y)}px; left: ${x(committedRobotState.x)}px; transform: translate(-50%, -50%) rotate(${committedRobotState.heading}deg); z-index: 20; width: ${Math.abs(x(settings.rLength || DEFAULT_ROBOT_LENGTH) - x(0))}px; height: ${Math.abs(x(settings.rWidth || DEFAULT_ROBOT_WIDTH) - x(0))}px; pointer-events: none; background-color: rgba(239, 68, 68, 0.5); border: 2px solid #dc2626;`}
         ></div>
       {/if}
+    {/if}
+
+    <!-- Timeline Hover Ghost Robot -->
+    {#if hoverRobotXY && hoverRobotHeading !== null && $showRobot && settings.robotImage !== "none"}
+      <div
+        class="field-element transition-all duration-[20ms] ease-linear pointer-events-none"
+        style={`position: absolute; top: ${y(hoverRobotXY.y)}px; left: ${x(hoverRobotXY.x)}px; transform: translate(-50%, -50%) rotate(${hoverRobotHeading}deg); z-index: 21; width: ${Math.abs(x(settings.rLength || DEFAULT_ROBOT_LENGTH) - x(0))}px; height: ${Math.abs(x(settings.rWidth || DEFAULT_ROBOT_WIDTH) - x(0))}px; opacity: 0.5;`}
+      >
+        <img
+          src={settings.robotImage || "/robot.png"}
+          alt="Hover Ghost Robot"
+          class="w-full h-full object-contain pointer-events-none"
+          draggable="false"
+          style={`filter: drop-shadow(0px 2px 8px rgba(0,0,0,0.4)) ${
+            settings.robotImage === "/robot.png"
+              ? ""
+              : "drop-shadow(0px 0px 4px rgba(255,255,255,0.6))"
+          };`}
+        />
+        {#if settings.showFakeHeadingArrow && settings.robotImage !== "/robot.png"}
+          <!-- heading arrow indicator for custom robot image -->
+          <div
+            class="absolute pointer-events-none"
+            style="left: 100%; top: 50%; transform: translate(-10%, -50%);"
+          >
+            <div
+              class="w-0 h-0"
+              style="border-top: 6px solid transparent; border-bottom: 6px solid transparent; border-left: 10px solid #16a34a;"
+            ></div>
+          </div>
+        {/if}
+      </div>
+    {:else if hoverRobotXY && hoverRobotHeading !== null && $showRobot && settings.robotImage === "none"}
+      <div
+        class="field-element transition-all duration-[20ms] ease-linear pointer-events-none"
+        style={`position: absolute; top: ${y(hoverRobotXY.y)}px; left: ${x(hoverRobotXY.x)}px; transform: translate(-50%, -50%) rotate(${hoverRobotHeading}deg); z-index: 21; width: ${Math.abs(x(settings.rLength || DEFAULT_ROBOT_LENGTH) - x(0))}px; height: ${Math.abs(x(settings.rWidth || DEFAULT_ROBOT_WIDTH) - x(0))}px; background-color: rgba(100, 116, 139, 0.3); border: 2px dashed #94a3b8; border-radius: 8px;`}
+      >
+        <!-- heading arrow indicator for no-image robot -->
+        <div
+          class="absolute pointer-events-none"
+          style="left: 100%; top: 50%; transform: translate(-10%, -50%);"
+        >
+          <div
+            class="w-0 h-0"
+            style="border-top: 8px solid transparent; border-bottom: 8px solid transparent; border-left: 12px solid #94a3b8;"
+          ></div>
+        </div>
+      </div>
     {/if}
 
     <!-- Telemetry Ghost Robot -->

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -3046,7 +3046,7 @@
     {/if}
 
     <!-- Timeline Hover Ghost Robot -->
-    {#if hoverRobotXY && hoverRobotHeading !== null && $showRobot && settings.robotImage !== "none"}
+    {#if hoverRobotXY && hoverRobotHeading !== null && $showRobot && settings.robotImage !== "none" && settings.robotImage !== "turtle"}
       <div
         class="field-element transition-all duration-[20ms] ease-linear pointer-events-none"
         style={`position: absolute; top: ${y(hoverRobotXY.y)}px; left: ${x(hoverRobotXY.x)}px; transform: translate(-50%, -50%) rotate(${hoverRobotHeading}deg); z-index: 21; width: ${Math.abs(x(settings.rLength || DEFAULT_ROBOT_LENGTH) - x(0))}px; height: ${Math.abs(x(settings.rWidth || DEFAULT_ROBOT_WIDTH) - x(0))}px; opacity: 0.5;`}
@@ -3075,7 +3075,7 @@
           </div>
         {/if}
       </div>
-    {:else if hoverRobotXY && hoverRobotHeading !== null && $showRobot && settings.robotImage === "none"}
+    {:else if hoverRobotXY && hoverRobotHeading !== null && $showRobot && (settings.robotImage === "none" || settings.robotImage === "turtle")}
       <div
         class="field-element transition-all duration-[20ms] ease-linear pointer-events-none"
         style={`position: absolute; top: ${y(hoverRobotXY.y)}px; left: ${x(hoverRobotXY.x)}px; transform: translate(-50%, -50%) rotate(${hoverRobotHeading}deg); z-index: 21; width: ${Math.abs(x(settings.rLength || DEFAULT_ROBOT_LENGTH) - x(0))}px; height: ${Math.abs(x(settings.rWidth || DEFAULT_ROBOT_WIDTH) - x(0))}px; background-color: rgba(100, 116, 139, 0.3); border: 2px dashed #94a3b8; border-radius: 8px;`}

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -6,7 +6,11 @@
   import { menuNavigation } from "../actions/menuNavigation";
   import { formatTime, getShortcutFromSettings } from "../../utils";
   import { onMount, onDestroy } from "svelte";
-  import { loopRangeActiveStore, loopRangeStore } from "../../lib/projectStore";
+  import {
+    loopRangeActiveStore,
+    loopRangeStore,
+    hoverPercentStore,
+  } from "../../lib/projectStore";
   import ContextMenu from "./tools/ContextMenu.svelte";
   import {
     ArrowCircleIcon,
@@ -72,6 +76,8 @@
 
   // Drag State
   let draggingMarkerIndex: number | null = $state(null);
+  let hoverX = $state<number | null>(null);
+  let hoverPercentRaw = $state<number | null>(null);
   let draggingMarkerId: string | null = null;
   let draggingMarkerPercent: number = $state(0);
   let wasPlayingBeforeDrag: boolean = false;
@@ -161,6 +167,23 @@
     let newPercent = percent + amount;
     newPercent = Math.max(0, Math.min(100, newPercent));
     handleSeek(newPercent);
+  }
+
+  function handleSliderMouseMove(e: MouseEvent) {
+    if (draggingMarkerIndex !== null) return;
+    const target = e.currentTarget as HTMLElement;
+    const rect = target.getBoundingClientRect();
+    const x = Math.max(0, Math.min(e.clientX - rect.left, rect.width));
+    const p = (x / rect.width) * 100;
+    hoverX = x;
+    hoverPercentRaw = p;
+    hoverPercentStore.set(p);
+  }
+
+  function handleSliderMouseLeave() {
+    hoverX = null;
+    hoverPercentRaw = null;
+    hoverPercentStore.set(null);
   }
 
   function handleSeekInput(e: Event) {
@@ -483,6 +506,24 @@
       </div>
     {/if}
 
+    <!-- Hover Tooltip -->
+    {#if hoverX !== null && hoverPercentRaw !== null && draggingMarkerIndex === null}
+      <div
+        class="absolute z-30 bottom-full mb-2 -ml-6 w-12 text-center pointer-events-none"
+        style="left: {hoverPercentRaw}%;"
+      >
+        <div
+          class="px-2 py-1 bg-neutral-800 dark:bg-neutral-200 text-neutral-100 dark:text-neutral-800 text-[10px] font-mono rounded shadow-lg"
+        >
+          {formatTime(((hoverPercentRaw / 100) * totalSeconds) / 1000)}
+        </div>
+        <!-- Little triangle arrow -->
+        <div
+          class="w-0 h-0 border-l-[4px] border-l-transparent border-r-[4px] border-r-transparent border-t-[4px] border-t-neutral-800 dark:border-t-neutral-200 mx-auto"
+        ></div>
+      </div>
+    {/if}
+
     <!-- The Slider -->
     <input
       id="timeline-slider"
@@ -496,6 +537,8 @@
       style={draggingMarkerIndex === null ? "" : "pointer-events: none;"}
       oninput={handleSeekInput}
       onkeydown={handleSliderKeydown}
+      onmousemove={handleSliderMouseMove}
+      onmouseleave={handleSliderMouseLeave}
     />
 
     <!-- Event Markers Layer (Top, Map Pins) -->

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -515,7 +515,7 @@
         <div
           class="px-2 py-1 bg-neutral-800 dark:bg-neutral-200 text-neutral-100 dark:text-neutral-800 text-[10px] font-mono rounded shadow-lg"
         >
-          {formatTime(((hoverPercentRaw / 100) * totalSeconds) / 1000)}
+          {formatTime((hoverPercentRaw / 100) * totalSeconds)}
         </div>
         <!-- Little triangle arrow -->
         <div

--- a/src/lib/projectStore.ts
+++ b/src/lib/projectStore.ts
@@ -135,6 +135,11 @@ const loadingMacros = new Set<string>();
 
 // Animation state
 export const percentStore = writable(0);
+export const hoverPercentStore = writable<number | null>(null);
+export const hoverRobotXYStore = writable<{ x: number; y: number } | null>(
+  null,
+);
+export const hoverRobotHeadingStore = writable<number | null>(null);
 export const playingStore = writable(false);
 export const playbackSpeedStore = writable(1);
 export const loopAnimationStore = writable(true);


### PR DESCRIPTION
What: Added a new feature that provides a live time-scrubbing preview when users hover over the playback timeline slider. It displays a tooltip with the estimated time at the hovered percentage and visually places a translucent 'Ghost Robot' on the field corresponding to that specific predicted state.

Why: Users frequently want to know exactly what point in time or what position on the field corresponds to a certain percentage on the timeline slider. Rather than having to drag and alter the playing state just to check, a hover preview provides an instant, non-destructive way to explore path timing and kinematics. This brings the workflow closer to modern video scrubbing interfaces (like YouTube) and provides immediate, tangible feedback.

Behavior:
1. Hovering the mouse over the main timeline slider (`#timeline-slider`) calculates the percentage corresponding to the mouse's X position.
2. A sleek tooltip rendered above the slider displays the precise time (in `m:ss.ms` format) at that location.
3. The `App.svelte` core reactive loop reads this `hoverPercentStore` value, computes the kinematic state of the robot via `calculateRobotState()`, and populates `hoverRobotXYStore` and `hoverRobotHeadingStore`.
4. `FieldRenderer.svelte` subscribes to these stores and renders a highly transparent Ghost Robot overlay at the target position, showing exactly where the robot will be and where it is facing.
5. Mouse leave instantly clears the tooltip and the Ghost Robot.

Verification:
- The tests run smoothly. Build succeeds without any unresolved module errors.
- Visual logic uses declarative rendering (`{#if hoverX ...}`) directly over the Svelte components safely. Wait/Event interactions on the timeline itself still act identically since mouse drag events are conditionally skipped while scrubbing.

---
*PR created automatically by Jules for task [4776845243445926986](https://jules.google.com/task/4776845243445926986) started by @Mallen220*