### PR TITLE
Feature: Improve Accessibility for Path Statistics Dialog

### DIFF
--- a/src/lib/components/dialogs/PathStatisticsDialog.svelte
+++ b/src/lib/components/dialogs/PathStatisticsDialog.svelte
@@ -653,6 +653,7 @@
           <button
             class={`px-3 py-1 rounded-md transition-all ${activeTab === "insights" ? "bg-white dark:bg-neutral-600 shadow-sm text-neutral-900 dark:text-white" : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300"}`}
             onclick={() => (activeTab = "insights")}
+            aria-label="Insights view"
           >
             Insights
           </button>
@@ -666,7 +667,9 @@
           title={activeTab === "graphs"
             ? "Copy SVG to Clipboard"
             : "Copy as Markdown"}
-          aria-label="Copy content"
+          aria-label={activeTab === "graphs"
+            ? "Copy SVG to Clipboard"
+            : "Copy as Markdown"}
         >
           <ClipboardIcon className="size-5" />
         </button>


### PR DESCRIPTION
This PR improves accessibility by adding proper `aria-label`s to the icon-only buttons in `PathStatisticsDialog.svelte`, ensuring that screen readers convey the correct context, such as the dynamically changing "Copy SVG to Clipboard" / "Copy as Markdown" text.

---
*PR created automatically by Jules for task [11612929809663154666](https://jules.google.com/task/11612929809663154666) started by @Mallen220*