### PR TITLE
✨ Feature: Accessible icon-only buttons

### DIFF
--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -514,7 +514,7 @@
     <button
       id="sidebar-toggle-btn"
       title={`${showSidebar ? "Hide Sidebar" : "Show Sidebar"}${getShortcutFromSettings(settings, "toggle-sidebar")}`}
-      aria-label={showSidebar ? "Hide Sidebar" : "Show Sidebar"}
+      aria-label={`${showSidebar ? "Hide Sidebar" : "Show Sidebar"}${getShortcutFromSettings(settings, "toggle-sidebar")}`}
       onclick={() => (showSidebar = !showSidebar)}
       class="p-2 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-800 text-neutral-600 dark:text-neutral-300 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"
     >

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -3330,7 +3330,7 @@
               ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/50'
               : 'hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200'}"
             onclick={toggleDiff}
-            aria-label={isDiffMode ? "Exit Visual Diff" : "Toggle Visual Diff"}
+            aria-label={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
             title={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
           >
             {#if $isLoadingDiff}

--- a/src/lib/components/LeftSidebar.svelte
+++ b/src/lib/components/LeftSidebar.svelte
@@ -368,7 +368,7 @@
         >
           <button
             title={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
-            aria-label={item.label}
+            aria-label={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
             aria-pressed={isActive}
             onclick={() => item.settingKey && toggleSetting(item.settingKey)}
             class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -451,7 +451,7 @@
             <button
               id="sidebar-file-manager-btn"
               title={`Open File Manager${getShortcutFromSettings(settings, "toggle-file-manager")}`}
-              aria-label="Open File Manager"
+              aria-label={`Open File Manager${getShortcutFromSettings(settings, "toggle-file-manager")}`}
               onclick={() => showFileManager.set(true)}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:text-purple-600 dark:hover:text-purple-400 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -492,7 +492,9 @@
               title={item.shortcutKey && settings.keyBindings
                 ? `${item.label} (${getShortcutFromSettings(settings, item.shortcutKey)})`
                 : item.label}
-              aria-label={item.label}
+              aria-label={item.shortcutKey && settings.keyBindings
+                ? `${item.label} (${getShortcutFromSettings(settings, item.shortcutKey)})`
+                : item.label}
               onclick={() => showShortcuts.set(true)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -613,7 +615,7 @@
               <button
                 bind:this={historyButtonRef}
                 title={`History Panel${getShortcutFromSettings(settings, "toggle-history")}`}
-                aria-label="History Panel"
+                aria-label={`History Panel${getShortcutFromSettings(settings, "toggle-history")}`}
                 aria-haspopup="menu"
                 aria-expanded={$showHistory}
                 aria-controls="history-menu"
@@ -749,7 +751,7 @@
           >
             <button
               title={`Draw Path${getShortcutFromSettings(settings, "toggle-draw")}`}
-              aria-label="Draw Path"
+              aria-label={`Draw Path${getShortcutFromSettings(settings, "toggle-draw")}`}
               aria-pressed={$isDrawingMode}
               onclick={() => isDrawingMode.update((v) => !v)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -788,7 +790,7 @@
           >
             <button
               title={`Toggle Ruler${getShortcutFromSettings(settings, "toggle-ruler")}`}
-              aria-label="Toggle Ruler"
+              aria-label={`Toggle Ruler${getShortcutFromSettings(settings, "toggle-ruler")}`}
               aria-pressed={$showRuler}
               onclick={() => showRuler.update((v) => !v)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -825,7 +827,7 @@
           >
             <button
               title={`Toggle Protractor${getShortcutFromSettings(settings, "toggle-protractor")}`}
-              aria-label="Toggle Protractor"
+              aria-label={`Toggle Protractor${getShortcutFromSettings(settings, "toggle-protractor")}`}
               aria-pressed={$showProtractor}
               onclick={() => showProtractor.update((v) => !v)}
               class="p-1.5 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -892,7 +894,7 @@
           >
             <button
               title={`Toggle Grid${getShortcutFromSettings(settings, "toggle-grid")}`}
-              aria-label="Toggle Grid"
+              aria-label={`Toggle Grid${getShortcutFromSettings(settings, "toggle-grid")}`}
               aria-pressed={$showGrid}
               onclick={() => showGrid.update((v) => !v)}
               class="p-1.5 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -915,7 +917,7 @@
             {#if $showGrid}
               <button
                 title={`Toggle Snap${getShortcutFromSettings(settings, "toggle-snap")}`}
-                aria-label={$snapToGrid ? "Disable Snap" : "Enable Snap"}
+                aria-label={`Toggle Snap${getShortcutFromSettings(settings, "toggle-snap")}`}
                 aria-pressed={$snapToGrid}
                 onclick={() => snapToGrid.update((v) => !v)}
                 class="p-1 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -980,7 +982,7 @@
           >
             <button
               title={`Toggle Onion Skin${getShortcutFromSettings(settings, "toggle-onion")}`}
-              aria-label="Toggle Onion Skin"
+              aria-label={`Toggle Onion Skin${getShortcutFromSettings(settings, "toggle-onion")}`}
               aria-pressed={settings.showOnionLayers}
               onclick={() => {
                 settings.showOnionLayers = !settings.showOnionLayers;
@@ -1009,9 +1011,7 @@
             {#if settings.showOnionLayers}
               <button
                 title={`Toggle Current Path Only${getShortcutFromSettings(settings, "toggle-onion-current-path")}`}
-                aria-label={settings.onionSkinCurrentPathOnly
-                  ? "Show All Paths"
-                  : "Show Current Path Only"}
+                aria-label={`Toggle Current Path Only${getShortcutFromSettings(settings, "toggle-onion-current-path")}`}
                 aria-pressed={settings.onionSkinCurrentPathOnly}
                 onclick={() => {
                   settings.onionSkinCurrentPathOnly =
@@ -1057,7 +1057,7 @@
           >
             <button
               title={`Toggle Velocity Heatmap`}
-              aria-label="Toggle Velocity Heatmap"
+              aria-label={`Toggle Velocity Heatmap`}
               aria-pressed={settings.showVelocityHeatmap}
               onclick={() => {
                 settings.showVelocityHeatmap = !settings.showVelocityHeatmap;
@@ -1091,7 +1091,7 @@
           >
             <button
               title={`Toggle Field View Lock${getShortcutFromSettings(settings, "toggle-lock-view")}`}
-              aria-label="Toggle Field View Lock"
+              aria-label={`Toggle Field View Lock${getShortcutFromSettings(settings, "toggle-lock-view")}`}
               aria-pressed={settings.lockFieldView}
               onclick={() => {
                 settingsStore.update((s) => ({
@@ -1139,7 +1139,7 @@
             <button
               id="sidebar-new-path-btn"
               title={`New Path${getShortcutFromSettings(settings, "new-file")}`}
-              aria-label="New Path"
+              aria-label={`New Path${getShortcutFromSettings(settings, "new-file")}`}
               onclick={() => resetProject()}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -1175,7 +1175,7 @@
             <button
               id="sidebar-settings-btn"
               title={`Settings${getShortcutFromSettings(settings, "open-settings")}`}
-              aria-label="Settings"
+              aria-label={`Settings${getShortcutFromSettings(settings, "open-settings")}`}
               onclick={() => showSettings.set(true)}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -617,7 +617,7 @@
     <div class="relative">
       <button
         title="Open playback speed menu"
-        aria-label={`Playback speed options, current speed ${(playbackSpeed ?? 1).toFixed(2)}x`}
+        aria-label="Open playback speed menu"
         aria-haspopup="menu"
         aria-expanded={showSpeedMenu}
         onclick={(e) => {
@@ -712,7 +712,9 @@
         title={playing
           ? `Pause Animation${getShortcutFromSettings(settings, "play-pause")}`
           : `Play Animation${getShortcutFromSettings(settings, "play-pause")}`}
-        aria-label={playing ? "Pause animation" : "Play animation"}
+        aria-label={playing
+          ? `Pause Animation${getShortcutFromSettings(settings, "play-pause")}`
+          : `Play Animation${getShortcutFromSettings(settings, "play-pause")}`}
         onclick={() => {
           if (playing) {
             pause();
@@ -796,7 +798,7 @@
       <!-- Loop Toggle Button -->
       <button
         title={loopAnimation ? "Disable Loop" : "Enable Loop"}
-        aria-label="Loop animation"
+        aria-label={loopAnimation ? "Disable Loop" : "Enable Loop"}
         aria-pressed={loopAnimation}
         onclick={() => (loopAnimation = !loopAnimation)}
         class:opacity-100={loopAnimation}

--- a/src/lib/components/sections/ControlPointsSection.svelte
+++ b/src/lib/components/sections/ControlPointsSection.svelte
@@ -245,7 +245,7 @@
               >
                 <button
                   title={line.locked ? "Locked" : "Move up"}
-                  aria-label="Move control point up"
+                  aria-label={line.locked ? "Locked" : "Move up"}
                   onclick={(e) => {
                     e.stopPropagation();
                     moveControlPoint(idx, -1);
@@ -262,7 +262,7 @@
                 ></div>
                 <button
                   title={line.locked ? "Locked" : "Move down"}
-                  aria-label="Move control point down"
+                  aria-label={line.locked ? "Locked" : "Move down"}
                   onclick={(e) => {
                     e.stopPropagation();
                     moveControlPoint(idx, 1);

--- a/src/lib/components/sections/StartingPointSection.svelte
+++ b/src/lib/components/sections/StartingPointSection.svelte
@@ -225,7 +225,7 @@
     >
     <button
       onclick={addPathAtStart}
-      aria-label="Add Path after start"
+      aria-label={`Add Path${getShortcutFromSettings(settings, "add-path-start")}`}
       title={`Add Path${getShortcutFromSettings(settings, "add-path-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors border border-green-200 dark:border-green-800/30 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >
@@ -234,7 +234,7 @@
     </button>
     <button
       onclick={addWaitAtStart}
-      aria-label="Add Wait after start"
+      aria-label={`Add Wait${getShortcutFromSettings(settings, "add-wait-start")}`}
       title={`Add Wait${getShortcutFromSettings(settings, "add-wait-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors border border-amber-200 dark:border-amber-800/30 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >
@@ -243,7 +243,7 @@
     </button>
     <button
       onclick={addRotateAtStart}
-      aria-label="Add Rotate after start"
+      aria-label={`Add Rotate${getShortcutFromSettings(settings, "add-rotate-start")}`}
       title={`Add Rotate${getShortcutFromSettings(settings, "add-rotate-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-pink-50 dark:bg-pink-900/20 text-pink-600 dark:text-pink-400 hover:bg-pink-100 dark:hover:bg-pink-900/30 transition-colors border border-pink-200 dark:border-pink-800/30 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >

--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -418,7 +418,7 @@
       onclick={handleDownloadJava}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("purple")}`}
       title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
-      aria-label="Download generated file"
+      aria-label={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
       disabled={!code}
       aria-disabled={!code}
     >
@@ -438,7 +438,9 @@
         : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
       disabled={isGenerating || !code}
       aria-disabled={isGenerating || !code}
-      aria-label="Copy generated code"
+      aria-label={copyButtonText === "Copied!"
+        ? "Copied!"
+        : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
     >
       {#if isGenerating}
         <LoadingSpinner size="sm" color="text-white" showText={false} />

--- a/src/lib/components/tabs/Tabs.test.ts
+++ b/src/lib/components/tabs/Tabs.test.ts
@@ -236,7 +236,7 @@ describe("CodeTab", () => {
 
     expect(screen.getByText(/Previewing:.*/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Copy generated code" }),
+      screen.getByRole("button", { name: "Copy Code" }),
     ).toBeInTheDocument();
 
     await vi.waitFor(() => {

--- a/src/tests/PlaybackControls.test.ts
+++ b/src/tests/PlaybackControls.test.ts
@@ -26,7 +26,7 @@ describe("PlaybackControls", () => {
       props: createProps({ play }),
     });
 
-    const btn = screen.getByLabelText("Play animation");
+    const btn = screen.getByLabelText("Play Animation");
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);
@@ -39,7 +39,7 @@ describe("PlaybackControls", () => {
       props: createProps({ playing: true, pause }),
     });
 
-    const btn = screen.getByLabelText("Pause animation");
+    const btn = screen.getByLabelText("Pause Animation");
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);
@@ -51,7 +51,7 @@ describe("PlaybackControls", () => {
       props: createProps(),
     });
 
-    const loopBtn = screen.getByLabelText("Loop animation");
+    const loopBtn = screen.getByLabelText("Enable Loop");
     expect(loopBtn).toBeInTheDocument();
     expect(loopBtn).toHaveAttribute("aria-pressed", "false");
 
@@ -66,7 +66,7 @@ describe("PlaybackControls", () => {
       props: createProps({ setPlaybackSpeed }),
     });
 
-    const speedBtn = screen.getByLabelText(/Playback speed options/);
+    const speedBtn = screen.getByLabelText(/Open playback speed menu/);
     await fireEvent.click(speedBtn);
 
     const speedOption = screen.getByText("2.00x");


### PR DESCRIPTION
**What**
- Added and synchronized `aria-label` and `title` attributes on all icon-only `<button>` elements across the project (e.g., in `LeftSidebar`, `PlaybackControls`, `Navbar`, etc.).
- Updated affected component unit tests to find elements by their new label names.

**Why**
- Improves accessibility for screen readers while maintaining tooltips for visual users, aligning with UX/UI directives.

**Behavior**
- Hovering over buttons like "Copy Code" or the "Play/Pause" controls will show a consistent tooltip, and screen readers will dictate the exact same text.

**Verification**
- Run `npm run test` to verify no regressions in PlaybackControls or Tabs tests.

---
*PR created automatically by Jules for task [2750249134112286569](https://jules.google.com/task/2750249134112286569) started by @Mallen220*