### PR TITLE
✨ Feature: Synchronize button aria-labels with title attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turtle-tracer",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turtle-tracer",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Modified Apache 2.0",
       "dependencies": {
         "@types/d3": "^7.4.3",

--- a/src/lib/components/FieldRenderer.svelte
+++ b/src/lib/components/FieldRenderer.svelte
@@ -3330,7 +3330,7 @@
               ? 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400 hover:bg-purple-200 dark:hover:bg-purple-900/50'
               : 'hover:bg-neutral-200 dark:hover:bg-neutral-700 text-neutral-700 dark:text-neutral-200'}"
             onclick={toggleDiff}
-            aria-label={isDiffMode ? "Exit Visual Diff" : "Toggle Visual Diff"}
+            aria-label={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
             title={isDiffMode ? "Exit Diff Mode" : "Compare with Saved"}
           >
             {#if $isLoadingDiff}

--- a/src/lib/components/LeftSidebar.svelte
+++ b/src/lib/components/LeftSidebar.svelte
@@ -368,7 +368,7 @@
         >
           <button
             title={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
-            aria-label={item.label}
+            aria-label={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
             aria-pressed={isActive}
             onclick={() => item.settingKey && toggleSetting(item.settingKey)}
             class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -407,8 +407,8 @@
             : ''} {dragSourceIndex === idx ? 'opacity-30 scale-95' : ''}"
         >
           <button
-            title={item.label}
-            aria-label={item.label}
+            title={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
+            aria-label={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
             onclick={() => executeCommandBus.set(item.commandId ?? null)}
             class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
               ? 'w-[calc(100%-1.1rem)] px-3'
@@ -451,7 +451,7 @@
             <button
               id="sidebar-file-manager-btn"
               title={`Open File Manager${getShortcutFromSettings(settings, "toggle-file-manager")}`}
-              aria-label="Open File Manager"
+              aria-label={`Open File Manager${getShortcutFromSettings(settings, "toggle-file-manager")}`}
               onclick={() => showFileManager.set(true)}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 hover:text-purple-600 dark:hover:text-purple-400 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -489,10 +489,8 @@
               : ''} {dragSourceIndex === idx ? 'opacity-30 scale-95' : ''}"
           >
             <button
-              title={item.shortcutKey && settings.keyBindings
-                ? `${item.label} (${getShortcutFromSettings(settings, item.shortcutKey)})`
-                : item.label}
-              aria-label={item.label}
+              title={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
+              aria-label={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
               onclick={() => showShortcuts.set(true)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -530,8 +528,8 @@
               : ''} {dragSourceIndex === idx ? 'opacity-30 scale-95' : ''}"
           >
             <button
-              title={item.label}
-              aria-label={item.label}
+              title={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
+              aria-label={`${item.label}${item.shortcutKey ? getShortcutFromSettings(settings, item.shortcutKey) : ""}`}
               onclick={() => executeCommandBus.set("toggle-command-palette")}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -613,7 +611,7 @@
               <button
                 bind:this={historyButtonRef}
                 title={`History Panel${getShortcutFromSettings(settings, "toggle-history")}`}
-                aria-label="History Panel"
+                aria-label={`History Panel${getShortcutFromSettings(settings, "toggle-history")}`}
                 aria-haspopup="menu"
                 aria-expanded={$showHistory}
                 aria-controls="history-menu"
@@ -749,7 +747,7 @@
           >
             <button
               title={`Draw Path${getShortcutFromSettings(settings, "toggle-draw")}`}
-              aria-label="Draw Path"
+              aria-label={`Draw Path${getShortcutFromSettings(settings, "toggle-draw")}`}
               aria-pressed={$isDrawingMode}
               onclick={() => isDrawingMode.update((v) => !v)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -788,7 +786,7 @@
           >
             <button
               title={`Toggle Ruler${getShortcutFromSettings(settings, "toggle-ruler")}`}
-              aria-label="Toggle Ruler"
+              aria-label={`Toggle Ruler${getShortcutFromSettings(settings, "toggle-ruler")}`}
               aria-pressed={$showRuler}
               onclick={() => showRuler.update((v) => !v)}
               class="p-1.5 rounded-md transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -825,7 +823,7 @@
           >
             <button
               title={`Toggle Protractor${getShortcutFromSettings(settings, "toggle-protractor")}`}
-              aria-label="Toggle Protractor"
+              aria-label={`Toggle Protractor${getShortcutFromSettings(settings, "toggle-protractor")}`}
               aria-pressed={$showProtractor}
               onclick={() => showProtractor.update((v) => !v)}
               class="p-1.5 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -892,7 +890,7 @@
           >
             <button
               title={`Toggle Grid${getShortcutFromSettings(settings, "toggle-grid")}`}
-              aria-label="Toggle Grid"
+              aria-label={`Toggle Grid${getShortcutFromSettings(settings, "toggle-grid")}`}
               aria-pressed={$showGrid}
               onclick={() => showGrid.update((v) => !v)}
               class="p-1.5 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -915,7 +913,7 @@
             {#if $showGrid}
               <button
                 title={`Toggle Snap${getShortcutFromSettings(settings, "toggle-snap")}`}
-                aria-label={$snapToGrid ? "Disable Snap" : "Enable Snap"}
+                aria-label={`Toggle Snap${getShortcutFromSettings(settings, "toggle-snap")}`}
                 aria-pressed={$snapToGrid}
                 onclick={() => snapToGrid.update((v) => !v)}
                 class="p-1 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -980,7 +978,7 @@
           >
             <button
               title={`Toggle Onion Skin${getShortcutFromSettings(settings, "toggle-onion")}`}
-              aria-label="Toggle Onion Skin"
+              aria-label={`Toggle Onion Skin${getShortcutFromSettings(settings, "toggle-onion")}`}
               aria-pressed={settings.showOnionLayers}
               onclick={() => {
                 settings.showOnionLayers = !settings.showOnionLayers;
@@ -1009,9 +1007,7 @@
             {#if settings.showOnionLayers}
               <button
                 title={`Toggle Current Path Only${getShortcutFromSettings(settings, "toggle-onion-current-path")}`}
-                aria-label={settings.onionSkinCurrentPathOnly
-                  ? "Show All Paths"
-                  : "Show Current Path Only"}
+                aria-label={`Toggle Current Path Only${getShortcutFromSettings(settings, "toggle-onion-current-path")}`}
                 aria-pressed={settings.onionSkinCurrentPathOnly}
                 onclick={() => {
                   settings.onionSkinCurrentPathOnly =
@@ -1056,7 +1052,7 @@
               : ''} {dragSourceIndex === idx ? 'opacity-30 scale-95' : ''}"
           >
             <button
-              title={`Toggle Velocity Heatmap`}
+              title="Toggle Velocity Heatmap"
               aria-label="Toggle Velocity Heatmap"
               aria-pressed={settings.showVelocityHeatmap}
               onclick={() => {
@@ -1091,7 +1087,7 @@
           >
             <button
               title={`Toggle Field View Lock${getShortcutFromSettings(settings, "toggle-lock-view")}`}
-              aria-label="Toggle Field View Lock"
+              aria-label={`Toggle Field View Lock${getShortcutFromSettings(settings, "toggle-lock-view")}`}
               aria-pressed={settings.lockFieldView}
               onclick={() => {
                 settingsStore.update((s) => ({
@@ -1139,7 +1135,7 @@
             <button
               id="sidebar-new-path-btn"
               title={`New Path${getShortcutFromSettings(settings, "new-file")}`}
-              aria-label="New Path"
+              aria-label={`New Path${getShortcutFromSettings(settings, "new-file")}`}
               onclick={() => resetProject()}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'
@@ -1175,7 +1171,7 @@
             <button
               id="sidebar-settings-btn"
               title={`Settings${getShortcutFromSettings(settings, "open-settings")}`}
-              aria-label="Settings"
+              aria-label={`Settings${getShortcutFromSettings(settings, "open-settings")}`}
               onclick={() => showSettings.set(true)}
               class="p-1.5 rounded-md text-neutral-600 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-800 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
                 ? 'w-[calc(100%-1.1rem)] px-3'

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -712,7 +712,7 @@
         title={playing
           ? `Pause Animation${getShortcutFromSettings(settings, "play-pause")}`
           : `Play Animation${getShortcutFromSettings(settings, "play-pause")}`}
-        aria-label={playing ? "Pause animation" : "Play animation"}
+        aria-label={playing ? `Pause Animation${getShortcutFromSettings(settings, "play-pause")}` : `Play Animation${getShortcutFromSettings(settings, "play-pause")}`}
         onclick={() => {
           if (playing) {
             pause();

--- a/src/lib/components/filemanager/FileGrid.svelte
+++ b/src/lib/components/filemanager/FileGrid.svelte
@@ -611,12 +611,12 @@
             <!-- Kebab menu overlay (visible on hover) -->
             <button
               class="absolute top-1 right-1 p-1 rounded-full bg-white/80 dark:bg-neutral-800/80 shadow-sm opacity-0 group-hover:opacity-100 focus:opacity-100 transition-opacity"
+              title="More actions"
               aria-label="More actions"
               onclick={(e) => {
                 e.stopPropagation();
                 openContextMenuFromEvent(e, file);
               }}
-              title="More actions"
             >
               <EllipsisHorizontalIcon
                 className="size-4 text-neutral-600 dark:text-neutral-300"

--- a/src/lib/components/sections/ControlPointsSection.svelte
+++ b/src/lib/components/sections/ControlPointsSection.svelte
@@ -245,7 +245,7 @@
               >
                 <button
                   title={line.locked ? "Locked" : "Move up"}
-                  aria-label="Move control point up"
+                  aria-label={line.locked ? "Locked" : "Move up"}
                   onclick={(e) => {
                     e.stopPropagation();
                     moveControlPoint(idx, -1);
@@ -262,7 +262,7 @@
                 ></div>
                 <button
                   title={line.locked ? "Locked" : "Move down"}
-                  aria-label="Move control point down"
+                  aria-label={line.locked ? "Locked" : "Move down"}
                   onclick={(e) => {
                     e.stopPropagation();
                     moveControlPoint(idx, 1);

--- a/src/lib/components/sections/ObstaclesSection.svelte
+++ b/src/lib/components/sections/ObstaclesSection.svelte
@@ -323,9 +323,7 @@
               <div class="flex flex-row gap-1">
                 <button
                   title={shape.visible === false ? "Show Shape" : "Hide Shape"}
-                  aria-label={shape.visible === false
-                    ? "Show Shape"
-                    : "Hide Shape"}
+                  aria-label={shape.visible === false ? "Show Shape" : "Hide Shape"}
                   onclick={() => {
                     shapes[shapeIdx] = {
                       ...shapes[shapeIdx],
@@ -352,9 +350,7 @@
                 </button>
                 <button
                   title={shape.locked ? "Unlock Obstacle" : "Lock Obstacle"}
-                  aria-label={shape.locked
-                    ? "Unlock Obstacle"
-                    : "Lock Obstacle"}
+                  aria-label={shape.locked ? "Unlock Obstacle" : "Lock Obstacle"}
                   aria-pressed={shape.locked ?? false}
                   onclick={() => {
                     shapes[shapeIdx] = {

--- a/src/lib/components/sections/StartingPointSection.svelte
+++ b/src/lib/components/sections/StartingPointSection.svelte
@@ -225,7 +225,7 @@
     >
     <button
       onclick={addPathAtStart}
-      aria-label="Add Path after start"
+      aria-label={`Add Path${getShortcutFromSettings(settings, "add-path-start")}`}
       title={`Add Path${getShortcutFromSettings(settings, "add-path-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-green-50 dark:bg-green-900/20 text-green-600 dark:text-green-400 hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors border border-green-200 dark:border-green-800/30 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >
@@ -234,7 +234,7 @@
     </button>
     <button
       onclick={addWaitAtStart}
-      aria-label="Add Wait after start"
+      aria-label={`Add Wait${getShortcutFromSettings(settings, "add-wait-start")}`}
       title={`Add Wait${getShortcutFromSettings(settings, "add-wait-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-amber-50 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400 hover:bg-amber-100 dark:hover:bg-amber-900/30 transition-colors border border-amber-200 dark:border-amber-800/30 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >
@@ -243,7 +243,7 @@
     </button>
     <button
       onclick={addRotateAtStart}
-      aria-label="Add Rotate after start"
+      aria-label={`Add Rotate${getShortcutFromSettings(settings, "add-rotate-start")}`}
       title={`Add Rotate${getShortcutFromSettings(settings, "add-rotate-start")}`}
       class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-pink-50 dark:bg-pink-900/20 text-pink-600 dark:text-pink-400 hover:bg-pink-100 dark:hover:bg-pink-900/30 transition-colors border border-pink-200 dark:border-pink-800/30 focus:outline-none focus:ring-2 focus:ring-pink-500 focus:ring-offset-1 dark:focus:ring-offset-neutral-900"
     >

--- a/src/lib/components/tabs/CodeTab.svelte
+++ b/src/lib/components/tabs/CodeTab.svelte
@@ -418,7 +418,7 @@
       onclick={handleDownloadJava}
       class={`flex items-center gap-2 px-4 py-2 text-sm font-medium text-white rounded-md shadow-sm transition-colors focus:outline-none focus:ring-2 ${getButtonFilledClass("purple")}`}
       title={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
-      aria-label="Download generated file"
+      aria-label={`Download as ${format === "points" || format === "custom" ? ".txt" : format === "json" ? ".turt" : ".java"}${getShortcutFromSettings(settings, "download-java")}`}
       disabled={!code}
       aria-disabled={!code}
     >
@@ -438,7 +438,7 @@
         : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
       disabled={isGenerating || !code}
       aria-disabled={isGenerating || !code}
-      aria-label="Copy generated code"
+      aria-label={copyButtonText === "Copied!" ? "Copied!" : `Copy Code${getShortcutFromSettings(settings, "copy-code")}`}
     >
       {#if isGenerating}
         <LoadingSpinner size="sm" color="text-white" showText={false} />

--- a/src/lib/components/tabs/Tabs.test.ts
+++ b/src/lib/components/tabs/Tabs.test.ts
@@ -236,7 +236,7 @@ describe("CodeTab", () => {
 
     expect(screen.getByText(/Previewing:.*/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: "Copy generated code" }),
+      screen.getByRole("button", { name: "Copy Code" }),
     ).toBeInTheDocument();
 
     await vi.waitFor(() => {

--- a/src/tests/PlaybackControls.test.ts
+++ b/src/tests/PlaybackControls.test.ts
@@ -26,7 +26,7 @@ describe("PlaybackControls", () => {
       props: createProps({ play }),
     });
 
-    const btn = screen.getByLabelText("Play animation");
+    const btn = screen.getByLabelText(/Play Animation/);
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);
@@ -39,7 +39,7 @@ describe("PlaybackControls", () => {
       props: createProps({ playing: true, pause }),
     });
 
-    const btn = screen.getByLabelText("Pause animation");
+    const btn = screen.getByLabelText(/Pause Animation/);
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);


### PR DESCRIPTION
# What
Updated multiple Svelte UI components to ensure that the `aria-label` attributes on `<button>` elements match their corresponding `title` attributes. This includes dynamically injecting keyboard shortcuts and maintaining accurate states.

# Why
To improve accessibility and UX. Specifically, to prevent a disconnect where sighted users see one tooltip (e.g., with a shortcut or specific state) while screen reader users hear a different or incomplete description.

# Behavior
- `<button>` elements across `FieldRenderer`, `LeftSidebar`, `PlaybackControls`, `FileGrid`, `ObstaclesSection`, `StartingPointSection`, `ControlPointsSection`, and `CodeTab` now accurately expose the same textual information to screen readers as they do via hover tooltips.
- The Loop Animation toggle in `PlaybackControls` correctly retains a static `aria-label` while toggling an `aria-pressed` state.

# Verification
1. Run `npm run check` and `npm run test` to verify no regressions in the UI tests.
2. Verified that tests for `Tabs` and `PlaybackControls` that perform accessible DOM querying via `@testing-library/svelte` pass with the new label strings.

---
*PR created automatically by Jules for task [4528881840717837948](https://jules.google.com/task/4528881840717837948) started by @Mallen220*