### PR TITLE
Refactor duplicated test and library code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "turtle-tracer",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "turtle-tracer",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Modified Apache 2.0",
       "dependencies": {
         "@types/d3": "^7.4.3",

--- a/src/lib/pluginManager.ts
+++ b/src/lib/pluginManager.ts
@@ -49,29 +49,6 @@ export class PluginManager {
   private static allExporters: CustomExporter[] = [];
   private static allThemes: CustomTheme[] = [];
 
-  static readonly SHADOW_GLOBALS = [
-    "window",
-    "document",
-    "location",
-    "top",
-    "parent",
-    "self",
-    "globalThis",
-    "electronAPI",
-    "localStorage",
-    "sessionStorage",
-    "indexedDB",
-    "fetch",
-    "XMLHttpRequest",
-    "WebSocket",
-    "process",
-    "require",
-  ];
-
-  static readonly SHADOW_VALUES = PluginManager.SHADOW_GLOBALS.map(
-    () => undefined,
-  );
-
   static async init() {
     const electronAPI = (globalThis as any).electronAPI;
     if (!electronAPI?.listPlugins) return;
@@ -193,15 +170,35 @@ export class PluginManager {
 
     const proxyAPI = new Proxy(() => {}, handler);
 
+    const shadowGlobals = [
+      "window",
+      "document",
+      "location",
+      "top",
+      "parent",
+      "self",
+      "globalThis",
+      "electronAPI",
+      "localStorage",
+      "sessionStorage",
+      "indexedDB",
+      "fetch",
+      "XMLHttpRequest",
+      "WebSocket",
+      "process",
+      "require",
+    ];
+    const shadowValues = shadowGlobals.map(() => undefined);
+
     try {
       // Force strict mode and shadow sensitive globals
-      const fn = new Function( // NOSONAR
+      const fn = new Function(
         "turtle",
         "pedro",
-        ...PluginManager.SHADOW_GLOBALS,
+        ...shadowGlobals,
         `"use strict";\n${code}`,
       );
-      fn(proxyAPI, proxyAPI, ...PluginManager.SHADOW_VALUES);
+      fn(proxyAPI, proxyAPI, ...shadowValues);
     } catch (e) {
       // Ignore errors during metadata extraction
     }
@@ -509,14 +506,34 @@ export class PluginManager {
 
     // Execute safely-ish by shadowing sensitive globals and enforcing strict mode
     try {
+      const shadowGlobals = [
+        "window",
+        "document",
+        "location",
+        "top",
+        "parent",
+        "self",
+        "globalThis",
+        "electronAPI",
+        "localStorage",
+        "sessionStorage",
+        "indexedDB",
+        "fetch",
+        "XMLHttpRequest",
+        "WebSocket",
+        "process",
+        "require",
+      ];
+      const shadowValues = shadowGlobals.map(() => undefined);
+
       // pass 'turtle' (and legacy 'pedro') as the argument names
-      const fn = new Function( // NOSONAR
+      const fn = new Function(
         "turtle",
         "pedro",
-        ...PluginManager.SHADOW_GLOBALS,
+        ...shadowGlobals,
         `"use strict";\n${codeToExecute}`,
       );
-      fn(turtleAPI, turtleAPI, ...PluginManager.SHADOW_VALUES);
+      fn(turtleAPI, turtleAPI, ...shadowValues);
     } catch (e) {
       throw new Error(`Execution failed: ${e}`);
     }

--- a/src/lib/pluginManager.ts
+++ b/src/lib/pluginManager.ts
@@ -195,7 +195,7 @@ export class PluginManager {
 
     try {
       // Force strict mode and shadow sensitive globals
-      const fn = new Function(
+      const fn = new Function( // NOSONAR
         "turtle",
         "pedro",
         ...PluginManager.SHADOW_GLOBALS,
@@ -510,7 +510,7 @@ export class PluginManager {
     // Execute safely-ish by shadowing sensitive globals and enforcing strict mode
     try {
       // pass 'turtle' (and legacy 'pedro') as the argument names
-      const fn = new Function(
+      const fn = new Function( // NOSONAR
         "turtle",
         "pedro",
         ...PluginManager.SHADOW_GLOBALS,

--- a/src/lib/pluginManager.ts
+++ b/src/lib/pluginManager.ts
@@ -49,6 +49,29 @@ export class PluginManager {
   private static allExporters: CustomExporter[] = [];
   private static allThemes: CustomTheme[] = [];
 
+  static readonly SHADOW_GLOBALS = [
+    "window",
+    "document",
+    "location",
+    "top",
+    "parent",
+    "self",
+    "globalThis",
+    "electronAPI",
+    "localStorage",
+    "sessionStorage",
+    "indexedDB",
+    "fetch",
+    "XMLHttpRequest",
+    "WebSocket",
+    "process",
+    "require",
+  ];
+
+  static readonly SHADOW_VALUES = PluginManager.SHADOW_GLOBALS.map(
+    () => undefined,
+  );
+
   static async init() {
     const electronAPI = (globalThis as any).electronAPI;
     if (!electronAPI?.listPlugins) return;
@@ -170,35 +193,15 @@ export class PluginManager {
 
     const proxyAPI = new Proxy(() => {}, handler);
 
-    const shadowGlobals = [
-      "window",
-      "document",
-      "location",
-      "top",
-      "parent",
-      "self",
-      "globalThis",
-      "electronAPI",
-      "localStorage",
-      "sessionStorage",
-      "indexedDB",
-      "fetch",
-      "XMLHttpRequest",
-      "WebSocket",
-      "process",
-      "require",
-    ];
-    const shadowValues = shadowGlobals.map(() => undefined);
-
     try {
       // Force strict mode and shadow sensitive globals
       const fn = new Function(
         "turtle",
         "pedro",
-        ...shadowGlobals,
+        ...PluginManager.SHADOW_GLOBALS,
         `"use strict";\n${code}`,
       );
-      fn(proxyAPI, proxyAPI, ...shadowValues);
+      fn(proxyAPI, proxyAPI, ...PluginManager.SHADOW_VALUES);
     } catch (e) {
       // Ignore errors during metadata extraction
     }
@@ -506,34 +509,14 @@ export class PluginManager {
 
     // Execute safely-ish by shadowing sensitive globals and enforcing strict mode
     try {
-      const shadowGlobals = [
-        "window",
-        "document",
-        "location",
-        "top",
-        "parent",
-        "self",
-        "globalThis",
-        "electronAPI",
-        "localStorage",
-        "sessionStorage",
-        "indexedDB",
-        "fetch",
-        "XMLHttpRequest",
-        "WebSocket",
-        "process",
-        "require",
-      ];
-      const shadowValues = shadowGlobals.map(() => undefined);
-
       // pass 'turtle' (and legacy 'pedro') as the argument names
       const fn = new Function(
         "turtle",
         "pedro",
-        ...shadowGlobals,
+        ...PluginManager.SHADOW_GLOBALS,
         `"use strict";\n${codeToExecute}`,
       );
-      fn(turtleAPI, turtleAPI, ...shadowValues);
+      fn(turtleAPI, turtleAPI, ...PluginManager.SHADOW_VALUES);
     } catch (e) {
       throw new Error(`Execution failed: ${e}`);
     }

--- a/src/tests/fileHandlers.test.ts
+++ b/src/tests/fileHandlers.test.ts
@@ -18,6 +18,13 @@ import { registerCoreUI } from "../lib/coreRegistrations";
 import type { SequenceMacroItem } from "../types";
 import pkg from "../../package.json";
 
+function expectDefaultHeader(header: any) {
+  expect(header).toBeDefined();
+  expect(header.info).toBe("Created with Turtle Tracer");
+  expect(header.copyright).toContain("Copyright");
+  expect(header.link).toBe("https://github.com/Mallen220/TurtleTracer");
+}
+
 const macroKind = (): SequenceMacroItem["kind"] =>
   (actionRegistry.getAll().find((a: any) => a.isMacro)
     ?.kind as SequenceMacroItem["kind"]) ?? "macro";
@@ -299,12 +306,7 @@ describe("fileHandlers", () => {
 
       expect(content.version).toBe(pkg.version);
       expect(content.version).toBe(pkg.version);
-      expect(content.header).toBeDefined();
-      expect(content.header.info).toBe("Created with Turtle Tracer");
-      expect(content.header.copyright).toContain("Copyright");
-      expect(content.header.link).toBe(
-        "https://github.com/Mallen220/TurtleTracer",
-      );
+      expectDefaultHeader(content.header);
     });
 
     it("should NOT save settings in the project file", async () => {
@@ -481,13 +483,7 @@ describe("fileHandlers", () => {
       expect(callArgs).toBeDefined();
 
       const content = JSON.parse(callArgs![1] as string);
-
-      expect(content.header).toBeDefined();
-      expect(content.header.info).toBe("Created with Turtle Tracer");
-      expect(content.header.copyright).toContain("Copyright");
-      expect(content.header.link).toBe(
-        "https://github.com/Mallen220/TurtleTracer",
-      );
+      expectDefaultHeader(content.header);
     });
 
     it("updates startPoint headings based on path geometry", async () => {

--- a/src/tests/geometry.test.ts
+++ b/src/tests/geometry.test.ts
@@ -119,10 +119,7 @@ describe("Geometry Utils", () => {
   describe("convexHull", () => {
     it("returns convex hull of points", () => {
       const points = [
-        { x: 0, y: 0 },
-        { x: 10, y: 0 },
-        { x: 10, y: 10 },
-        { x: 0, y: 10 },
+        ...square,
         { x: 5, y: 5 }, // Inside point
       ];
 

--- a/src/tests/javaImporterFormats.test.ts
+++ b/src/tests/javaImporterFormats.test.ts
@@ -3,6 +3,13 @@ import { describe, it, expect } from "vitest";
 import { importJavaProject } from "../utils/javaImporter";
 
 describe("Java Importer Format Compatibility", () => {
+  function verifyCommonData(d: any) {
+    expect(d.startPoint.degrees).toBe(90);
+    expect(d.lines[0].name).toBe("a");
+    expect(d.lines[0].endPoint.heading).toBe("linear");
+    expect(d.lines[1].name).toBe("b");
+  }
+
   it("parses Format 1 correctly (SequentialCommandGroup + InstantCommand)", () => {
     const code1 = `
 package org.firstinspires.ftc.teamcode.Commands.AutoCommands;
@@ -83,16 +90,13 @@ public class Everythingtest extends SequentialCommandGroup {
     `;
     const data = importJavaProject(code1);
 
-    expect(data.startPoint.degrees).toBe(90);
+    verifyCommonData(data);
     expect(data.lines.length).toBe(8);
     expect(data.sequence.length).toBe(10);
-    expect(data.lines[0].name).toBe("a");
-    expect(data.lines[0].endPoint.heading).toBe("linear");
     expect((data.lines[0].endPoint as any).startDeg).toBe(90);
     expect((data.lines[0].endPoint as any).endDeg).toBe(180);
     expect((data.lines[0].endPoint as any).reverse).toBe(false);
 
-    expect(data.lines[1].name).toBe("b");
     expect((data.lines[1].endPoint as any).reverse).toBe(true);
 
     expect(data.lines[2].name).toBe("c");
@@ -160,14 +164,13 @@ public class TurtleTracerAutonomous extends OpMode {
     `;
 
     const data = importJavaProject(code2);
-    expect(data.startPoint.degrees).toBe(90);
+    verifyCommonData(data);
     expect(data.lines.length).toBe(8);
 
     // OpMode export does not generate actions in our standard Sequence array output for Wait/Turn
     // due to lack of a unified block in the actual Java export. The visualizer relies on paths.
     // Testing purely paths for this case.
 
-    expect(data.lines[1].name).toBe("b");
     expect(data.lines[1].endPoint.heading).toBe("linear");
     expect((data.lines[1].endPoint as any).startDeg).toBe(0);
     expect((data.lines[1].endPoint as any).endDeg).toBe(0);
@@ -246,13 +249,9 @@ public class reference extends Command {
 
     const data = importJavaProject(code3);
 
-    expect(data.startPoint.degrees).toBe(90);
+    verifyCommonData(data);
     expect(data.lines.length).toBe(2);
 
-    expect(data.lines[0].name).toBe("a");
-    expect(data.lines[0].endPoint.heading).toBe("linear");
-
-    expect(data.lines[1].name).toBe("b");
     expect((data.lines[1].endPoint as any).reverse).toBe(true);
 
     expect((data.sequence[2] as any).durationMs).toBe(110);

--- a/src/tests/keepInZones.test.ts
+++ b/src/tests/keepInZones.test.ts
@@ -70,6 +70,17 @@ describe("PathOptimizer Keep-In Zones", () => {
     shapes = [];
   });
 
+  function getCollisions(shapesArg: Shape[]) {
+    const optimizer = new PathOptimizer(
+      startPoint,
+      lines,
+      settings,
+      sequence,
+      shapesArg,
+    );
+    return optimizer.getCollisions();
+  }
+
   it("should report violation if robot is outside keep-in zone", () => {
     // Define a keep-in zone far away
     shapes = [
@@ -88,16 +99,7 @@ describe("PathOptimizer Keep-In Zones", () => {
       },
     ];
 
-    const optimizer = new PathOptimizer(
-      startPoint,
-      lines,
-      settings,
-      sequence,
-      shapes,
-    );
-
-    // Use getCollisions directly
-    const collisions = optimizer.getCollisions();
+    const collisions = getCollisions(shapes);
 
     expect(collisions.length).toBeGreaterThan(0);
     expect(collisions.some((c) => c.type === "keep-in")).toBe(true);
@@ -124,15 +126,7 @@ describe("PathOptimizer Keep-In Zones", () => {
       },
     ];
 
-    const optimizer = new PathOptimizer(
-      startPoint,
-      lines,
-      settings,
-      sequence,
-      shapes,
-    );
-
-    const collisions = optimizer.getCollisions();
+    const collisions = getCollisions(shapes);
 
     expect(collisions.length).toBe(0);
   });
@@ -156,15 +150,7 @@ describe("PathOptimizer Keep-In Zones", () => {
       },
     ];
 
-    const optimizer = new PathOptimizer(
-      startPoint,
-      lines,
-      settings,
-      sequence,
-      shapes,
-    );
-
-    const collisions = optimizer.getCollisions();
+    const collisions = getCollisions(shapes);
 
     expect(collisions.length).toBeGreaterThan(0);
     expect(collisions.some((c) => c.type === "keep-in")).toBe(true);
@@ -202,15 +188,7 @@ describe("PathOptimizer Keep-In Zones", () => {
       },
     ];
 
-    const optimizer = new PathOptimizer(
-      startPoint,
-      lines,
-      settings,
-      sequence,
-      shapes,
-    );
-
-    const collisions = optimizer.getCollisions();
+    const collisions = getCollisions(shapes);
 
     // Should have collisions in the gap
     // Collision might start before 40 (due to robot width) and end after 60

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -1,34 +1,36 @@
 // Copyright 2026 Matthew Allen. Licensed under the Modified Apache License, Version 2.0.
 declare global {
+  var electronAPI: {
+    getDirectory: () => Promise<string>;
+    setDirectory: (path?: string) => Promise<string | null>;
+    listFiles: (directory: string) => Promise<FileInfo[]>;
+    readFile: (filePath: string) => Promise<string>;
+    writeFile: (filePath: string, content: string) => Promise<boolean>;
+    deleteFile: (filePath: string) => Promise<boolean>;
+    fileExists: (filePath: string) => Promise<boolean>;
+    getSavedDirectory: () => Promise<string>;
+    createDirectory: (dirPath: string) => Promise<boolean>;
+    getDirectoryStats: (dirPath: string) => Promise<any>;
+    resolvePath: (base: string, relative: string) => Promise<string>;
+    makeRelativePath?: (base: string, relative: string) => Promise<string>;
+    renameFile: (
+      oldPath: string,
+      newPath: string,
+    ) => Promise<{ success: boolean; newPath: string }>;
+    openExternal?: (url: string) => Promise<boolean>;
+    onMenuAction?: (callback: (action: string) => void) => void;
+    showSaveDialog?: (options: any) => Promise<string | null>;
+    rendererReady?: () => Promise<void>;
+    onOpenFilePath?: (callback: (path: string) => void) => void;
+    saveFile?: (
+      content: string,
+      path?: string,
+    ) => Promise<{ success: boolean; filepath: string; error?: string }>;
+    copyFile?: (src: string, dest: string) => Promise<boolean>;
+    gitShow?: (filePath: string) => Promise<string | null>;
+  };
   interface Window {
-    electronAPI: {
-      getDirectory: () => Promise<string>;
-      setDirectory: (path?: string) => Promise<string | null>;
-      listFiles: (directory: string) => Promise<FileInfo[]>;
-      readFile: (filePath: string) => Promise<string>;
-      writeFile: (filePath: string, content: string) => Promise<boolean>;
-      deleteFile: (filePath: string) => Promise<boolean>;
-      fileExists: (filePath: string) => Promise<boolean>;
-      getSavedDirectory: () => Promise<string>;
-      createDirectory: (dirPath: string) => Promise<boolean>;
-      getDirectoryStats: (dirPath: string) => Promise<any>;
-      resolvePath: (base: string, relative: string) => Promise<string>;
-      renameFile: (
-        oldPath: string,
-        newPath: string,
-      ) => Promise<{ success: boolean; newPath: string }>;
-      openExternal?: (url: string) => Promise<boolean>;
-      onMenuAction?: (callback: (action: string) => void) => void;
-      showSaveDialog?: (options: any) => Promise<string | null>;
-      rendererReady?: () => Promise<void>;
-      onOpenFilePath?: (callback: (path: string) => void) => void;
-      saveFile?: (
-        content: string,
-        path?: string,
-      ) => Promise<{ success: boolean; filepath: string; error?: string }>;
-      copyFile?: (src: string, dest: string) => Promise<boolean>;
-      gitShow?: (filePath: string) => Promise<string | null>;
-    };
+    electronAPI: typeof electronAPI;
   }
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -13,30 +13,4 @@ interface ImportMeta {
 
 declare module "prettier-plugin-java";
 
-declare global {
-  interface Window {
-    electronAPI: any;
-  }
-  var electronAPI: {
-    getDirectory: () => Promise<string | null>;
-    setDirectory: (path?: string) => Promise<string | null>;
-    listFiles: (directory: string) => Promise<any[]>;
-    readFile: (filePath: string) => Promise<string>;
-    writeFile: (
-      filePath: string,
-      content: string,
-    ) => Promise<{ success: boolean; filepath: string; error?: string }>;
-    deleteFile: (filePath: string) => Promise<boolean>;
-    fileExists: (filePath: string) => Promise<boolean>;
-    getSavedDirectory: () => Promise<string>;
-    createDirectory: (dirPath: string) => Promise<boolean>;
-    getDirectoryStats: (dirPath: string) => Promise<any>;
-    renameFile: (
-      oldPath: string,
-      newPath: string,
-    ) => Promise<{ success: boolean; newPath: string }>;
-    resolvePath?: (base: string, relative: string) => Promise<string>;
-    makeRelativePath?: (base: string, relative: string) => Promise<string>;
-    copyFile?: (source: string, dest: string) => Promise<boolean>;
-  };
-}
+// electronAPI declaration removed to avoid duplication with src/types/types.d.ts


### PR DESCRIPTION
Refactor duplicated test and library code

Extracted shared assertions into reusable helper functions in `keepInZones.test.ts`, `fileHandlers.test.ts`, and `javaImporterFormats.test.ts`. Consolidated static globals and type definitions in `pluginManager.ts` and `types.d.ts` respectively. Code duplication significantly reduced.

---
*PR created automatically by Jules for task [4823903390988437997](https://jules.google.com/task/4823903390988437997) started by @Mallen220*