### PR TITLE
✨ Feature: Improve Button Accessibility

### DIFF
--- a/src/lib/components/HeadingControls.svelte
+++ b/src/lib/components/HeadingControls.svelte
@@ -570,6 +570,7 @@
                   onclick={() => removeTransition(i)}
                   class="text-red-500 hover:text-red-700 p-0.5 rounded hover:bg-red-500/10 transition-colors"
                   title="Remove Transition"
+                  aria-label="Remove Transition"
                 >
                   <TrashIcon className="size-3" />
                 </button>

--- a/src/lib/components/dialogs/ExportCodeDialog.svelte
+++ b/src/lib/components/dialogs/ExportCodeDialog.svelte
@@ -543,6 +543,7 @@
                 }}
                 class="p-1 hover:bg-red-100 dark:hover:bg-red-900/30 hover:text-red-500 rounded text-neutral-500 transition-colors"
                 aria-label="Close search"
+                title="Close search"
               >
                 <CloseIcon strokeWidth={2} className="size-4" />
               </button>
@@ -554,6 +555,7 @@
             onclick={() => (isOpen = false)}
             class="p-2 rounded-lg text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
             aria-label="Close export dialog"
+            title="Close export dialog"
           >
             <CloseIcon strokeWidth={2} className="size-5" />
           </button>

--- a/src/lib/components/dialogs/KeyboardShortcutsDialog.svelte
+++ b/src/lib/components/dialogs/KeyboardShortcutsDialog.svelte
@@ -366,6 +366,7 @@
             onclick={() => (isOpen = false)}
             class="p-2 rounded-lg hover:bg-neutral-200 dark:hover:bg-neutral-800 text-neutral-500 dark:text-neutral-400 transition-colors"
             aria-label="Close dialog"
+            title="Close dialog"
           >
             <CloseIcon className="size-6" />
           </button>
@@ -460,6 +461,7 @@
                           onclick={() => resetBinding(binding.id)}
                           class="text-xs text-neutral-400 hover:text-red-500 transition-colors"
                           title="Reset to default"
+                          aria-label="Reset to default"
                         >
                           <ArrowCircleIcon className="size-4" strokeWidth={2} />
                         </button>

--- a/src/lib/components/dialogs/PathStatisticsDialog.svelte
+++ b/src/lib/components/dialogs/PathStatisticsDialog.svelte
@@ -640,6 +640,7 @@
             class={`px-3 py-1 rounded-md transition-all ${activeTab === "summary" ? "bg-white dark:bg-neutral-600 shadow-sm text-neutral-900 dark:text-white" : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300"}`}
             onclick={() => (activeTab = "summary")}
             aria-label="Summary view"
+            title="Summary view"
           >
             Summary
           </button>
@@ -647,6 +648,7 @@
             class={`px-3 py-1 rounded-md transition-all ${activeTab === "graphs" ? "bg-white dark:bg-neutral-600 shadow-sm text-neutral-900 dark:text-white" : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300"}`}
             onclick={() => (activeTab = "graphs")}
             aria-label="Graphs view"
+            title="Graphs view"
           >
             Graphs
           </button>
@@ -654,6 +656,7 @@
             class={`px-3 py-1 rounded-md transition-all ${activeTab === "insights" ? "bg-white dark:bg-neutral-600 shadow-sm text-neutral-900 dark:text-white" : "text-neutral-500 dark:text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-300"}`}
             onclick={() => (activeTab = "insights")}
             aria-label="Insights view"
+            title="Insights view"
           >
             Insights
           </button>

--- a/src/lib/components/dialogs/PluginManagerDialog.svelte
+++ b/src/lib/components/dialogs/PluginManagerDialog.svelte
@@ -92,6 +92,7 @@
           <button
             onclick={() => (isOpen = false)}
             aria-label="Close"
+            title="Close"
             class="p-2 text-neutral-400 hover:text-neutral-600 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-800 rounded-lg transition-colors"
           >
             <CloseIcon className="size-6" />
@@ -256,6 +257,7 @@
                       onclick={() => (pluginToDelete = plugin)}
                       class="p-1.5 text-neutral-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 rounded transition-colors"
                       title="Delete plugin"
+                      aria-label="Delete plugin"
                     >
                       <TrashIcon className="size-4" />
                     </button>

--- a/src/lib/components/dialogs/RatingDialog.svelte
+++ b/src/lib/components/dialogs/RatingDialog.svelte
@@ -243,6 +243,7 @@
                 disabled={isSubmitting}
                 class="hover:scale-110 transition-transform focus:outline-none disabled:opacity-50"
                 aria-label="{star} star rating"
+                title="{star} star rating"
               >
                 <StarIcon
                   className="w-8 h-8 {rating >= star

--- a/src/lib/components/dialogs/TransformDialog.svelte
+++ b/src/lib/components/dialogs/TransformDialog.svelte
@@ -171,6 +171,7 @@
           onclick={() => (isOpen = false)}
           class="p-1 hover:bg-neutral-200 dark:hover:bg-neutral-700 rounded-md transition-colors"
           aria-label="Close"
+          title="Close"
         >
           <CloseIcon className="w-5 h-5 text-neutral-500" strokeWidth={2} />
         </button>

--- a/src/lib/components/sections/MacroSection.svelte
+++ b/src/lib/components/sections/MacroSection.svelte
@@ -338,6 +338,7 @@
               }}
               class={`flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium ${getSmallButtonClass(color)}`}
               title={`Add ${def.label} After`}
+              aria-label={`Add ${def.label} After`}
             >
               <PlusIcon className="size-3" />
               {def.label}

--- a/src/lib/components/sections/MacroTransformControls.svelte
+++ b/src/lib/components/sections/MacroTransformControls.svelte
@@ -370,6 +370,7 @@
               onclick={() => moveTransform(i, -1)}
               disabled={i === 0}
               aria-label="Move transform up"
+              title="Move transform up"
               class="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-0"
             >
               <ChevronUpIcon className="size-3" />
@@ -378,6 +379,7 @@
               onclick={() => moveTransform(i, 1)}
               disabled={i === (macro.transformations?.length ?? 0) - 1}
               aria-label="Move transform down"
+              title="Move transform down"
               class="p-0.5 text-neutral-400 hover:text-neutral-600 disabled:opacity-0"
             >
               <ChevronDownIcon className="size-3" />
@@ -385,6 +387,7 @@
             <button
               onclick={() => removeTransform(i)}
               aria-label="Remove transform"
+              title="Remove transform"
               class="p-0.5 text-red-400 hover:text-red-600 ml-1"
             >
               <TrashIcon className="size-3" />

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -634,6 +634,7 @@
                 }
               }}
               title="Jump to global source"
+              aria-label="Jump to global source"
             >
               <LinkIcon className="size-4 shrink-0 text-purple-500" />
               Overridden by Global Chain Heading

--- a/src/lib/components/settings/RobotFeaturesEditor.svelte
+++ b/src/lib/components/settings/RobotFeaturesEditor.svelte
@@ -372,6 +372,9 @@
                   title={feature.visible === false
                     ? "Show Feature"
                     : "Hide Feature"}
+                  aria-label={feature.visible === false
+                    ? "Show Feature"
+                    : "Hide Feature"}
                 >
                   {#if feature.visible === false}
                     <EyeSlashIcon className="w-4 h-4" />
@@ -386,6 +389,7 @@
                     removeFeature(feature.id);
                   }}
                   title="Remove Feature"
+                  aria-label="Remove Feature"
                 >
                   <CloseIcon className="w-4 h-4" />
                 </button>

--- a/src/lib/components/settings/RobotProfileManager.svelte
+++ b/src/lib/components/settings/RobotProfileManager.svelte
@@ -291,6 +291,7 @@
             document.getElementById("profile-import-input")?.click()}
           class="text-xs px-2 py-1 bg-neutral-100 text-neutral-700 dark:bg-neutral-800 dark:text-neutral-300 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
           aria-label="Import profile"
+          title="Import profile"
         >
           Import
         </button>
@@ -298,6 +299,7 @@
           onclick={() => (isCreating = true)}
           class="text-xs px-2 py-1 bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300 rounded hover:bg-green-200 dark:hover:bg-green-900/50 transition-colors"
           aria-label="Create new profile"
+          title="Create new profile"
         >
           + New Profile
         </button>

--- a/src/lib/components/settings/tabs/GeneralSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/GeneralSettingsTab.svelte
@@ -337,6 +337,7 @@
         onclick={() =>
           document.getElementById("settings-import-input")?.click()}
         title="Import Settings"
+        aria-label="Import Settings"
         class="px-3 py-1.5 text-xs font-medium text-neutral-700 dark:text-neutral-300 bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 rounded-md transition-colors"
       >
         Import

--- a/src/lib/components/settings/tabs/SidebarSettingsTab.svelte
+++ b/src/lib/components/settings/tabs/SidebarSettingsTab.svelte
@@ -414,6 +414,7 @@
               disabled={idx === 0}
               class="p-1 rounded text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="Move up"
+              aria-label="Move up"
             >
               <ICONS.ChevronUpIcon className="size-4" />
             </button>
@@ -422,6 +423,7 @@
               disabled={idx === activeSidebarList.length - 1}
               class="p-1 rounded text-neutral-400 hover:text-neutral-700 dark:hover:text-neutral-200 hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
               title="Move down"
+              aria-label="Move down"
             >
               <ICONS.ChevronDownIcon className="size-4" />
             </button>
@@ -429,6 +431,7 @@
               onclick={() => removeSidebarItem(idx)}
               class="p-1 hover:bg-red-100 dark:hover:bg-red-900/40 text-neutral-400 hover:text-red-500 dark:hover:text-red-400 rounded transition-colors"
               title="Remove from sidebar"
+              aria-label="Remove from sidebar"
             >
               <ICONS.CloseIcon className="size-4" />
             </button>
@@ -716,6 +719,7 @@
                                     : 'bg-transparent border-transparent text-neutral-600 dark:text-neutral-300 hover:bg-neutral-100 dark:hover:bg-neutral-800'}"
                                   onclick={() => selectCustomIcon(iconDef.name)}
                                   title={iconDef.name}
+                                  aria-label={iconDef.name}
                                 >
                                   <iconDef.component
                                     className="size-5 shrink-0"

--- a/src/lib/components/tools/CollapseAllButton.svelte
+++ b/src/lib/components/tools/CollapseAllButton.svelte
@@ -12,6 +12,7 @@
   onclick={() => onToggle && onToggle()}
   class="text-sm mb-2 px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 border border-neutral-200 dark:border-neutral-700"
   aria-label={allCollapsed ? "Expand All" : "Collapse All"}
+  title={allCollapsed ? "Expand All" : "Collapse All"}
 >
   {#if allCollapsed}
     <span class="whitespace-nowrap">Expand All</span>

--- a/src/lib/components/whats-new/WhatsNewDialog.svelte
+++ b/src/lib/components/whats-new/WhatsNewDialog.svelte
@@ -196,6 +196,7 @@
                 onclick={() => (viewMode = "features")}
                 class="p-1 -ml-1 text-neutral-500 hover:text-neutral-800 dark:hover:text-neutral-200 transition-colors rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700"
                 aria-label="Back"
+                title="Back"
               >
                 <ChevronLeftIcon className="h-5 w-5" />
               </button>


### PR DESCRIPTION
✨ Feature: Improve Button Accessibility

**What:** Added missing `aria-label` and `title` attributes to numerous icon buttons across the application.
**Why:** To comply with user directives to improve UI/UX and accessibility. Icon-only buttons without these attributes are difficult to understand for screen readers and lack hover tooltips for sighted users.
**Behavior:** Hovering over previously unlabeled buttons (like 'Move Up' or 'Close' in various dialogs and tables) will now display a tooltip. Screen readers will now announce these actions correctly.
**Verification:** Run `npm run check`, `npm run test`, and `npm run test:e2e` to verify no regressions were introduced. Evaluated manually that buttons in MacroSection, TransformDialog, etc. now have both tags properly inserted via AST parser script.

---
*PR created automatically by Jules for task [18270624877815110633](https://jules.google.com/task/18270624877815110633) started by @Mallen220*