### PR TITLE
✨ Feature: Enhance toggle button accessibility with ARIA states

### DIFF
--- a/src/lib/components/LeftSidebar.svelte
+++ b/src/lib/components/LeftSidebar.svelte
@@ -850,9 +850,7 @@
                 title={$protractorLockToRobot
                   ? "Unlock Protractor from Robot"
                   : "Lock Protractor to Robot"}
-                aria-label={$protractorLockToRobot
-                  ? "Unlock Protractor from Robot"
-                  : "Lock Protractor to Robot"}
+                aria-label="Toggle Protractor Lock to Robot"
                 aria-pressed={$protractorLockToRobot}
                 onclick={() => protractorLockToRobot.update((v) => !v)}
                 class="p-1 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -915,7 +913,7 @@
             {#if $showGrid}
               <button
                 title={`Toggle Snap${getShortcutFromSettings(settings, "toggle-snap")}`}
-                aria-label={$snapToGrid ? "Disable Snap" : "Enable Snap"}
+                aria-label="Toggle Snap to Grid"
                 aria-pressed={$snapToGrid}
                 onclick={() => snapToGrid.update((v) => !v)}
                 class="p-1 rounded-md transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 flex items-center {sidebarExpanded
@@ -1009,9 +1007,7 @@
             {#if settings.showOnionLayers}
               <button
                 title={`Toggle Current Path Only${getShortcutFromSettings(settings, "toggle-onion-current-path")}`}
-                aria-label={settings.onionSkinCurrentPathOnly
-                  ? "Show All Paths"
-                  : "Show Current Path Only"}
+                aria-label="Toggle Onion Skin Current Path Only"
                 aria-pressed={settings.onionSkinCurrentPathOnly}
                 onclick={() => {
                   settings.onionSkinCurrentPathOnly =
@@ -1553,7 +1549,7 @@
     <div class="w-full flex justify-center">
       <button
         title={sidebarExpanded ? "Collapse Sidebar" : "Expand Sidebar"}
-        aria-label={sidebarExpanded ? "Collapse Sidebar" : "Expand Sidebar"}
+        aria-label="Toggle Sidebar Expansion"
         aria-expanded={sidebarExpanded}
         aria-controls="sidebar-toolbar"
         onclick={toggleSidebar}

--- a/src/lib/components/PlaybackControls.svelte
+++ b/src/lib/components/PlaybackControls.svelte
@@ -712,7 +712,8 @@
         title={playing
           ? `Pause Animation${getShortcutFromSettings(settings, "play-pause")}`
           : `Play Animation${getShortcutFromSettings(settings, "play-pause")}`}
-        aria-label={playing ? "Pause animation" : "Play animation"}
+        aria-label="Toggle Animation Playback"
+        aria-pressed={playing}
         onclick={() => {
           if (playing) {
             pause();

--- a/src/lib/components/WaypointTable.svelte
+++ b/src/lib/components/WaypointTable.svelte
@@ -1641,7 +1641,7 @@
                 <!-- Eye/Hide icon -->
                 <button
                   title={line.hidden ? "Show Path" : "Hide Path"}
-                  aria-label={line.hidden ? "Show Path" : "Hide Path"}
+                  aria-label="Toggle Path Visibility"
                   onclick={(e) => {
                     e.stopPropagation();
                     const lIdx = lines.findIndex((l) => l.id === line.id);
@@ -1655,6 +1655,7 @@
                     if (recordChange) recordChange();
                   }}
                   class="inline-flex items-center justify-center h-6 w-6 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
+                  aria-pressed={!line.hidden}
                 >
                   {#if line.hidden}
                     <EyeSlashIcon className="size-5 text-neutral-400" />
@@ -1666,7 +1667,8 @@
                 <!-- Left slot: lock/unlock button always visible -->
                 <button
                   title={line.locked ? "Unlock Path" : "Lock Path"}
-                  aria-label={line.locked ? "Unlock Path" : "Lock Path"}
+                  aria-label="Toggle Path Lock"
+                  aria-pressed={line.locked}
                   onclick={(e) => {
                     e.stopPropagation();
                     const lIdx = lines.findIndex((l) => l.id === line.id);
@@ -1680,7 +1682,6 @@
                     if (recordChange) recordChange();
                   }}
                   class="inline-flex items-center justify-center h-6 w-6 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
-                  aria-pressed={line.locked}
                 >
                   {#if line.locked}
                     <LockIcon className="size-5 stroke-yellow-500" />

--- a/src/lib/components/sections/MacroSection.svelte
+++ b/src/lib/components/sections/MacroSection.svelte
@@ -118,7 +118,7 @@
         }}
         class="flex items-center gap-2 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-500 transition-colors px-1 py-1"
         title="{collapsed ? 'Expand' : 'Collapse'} macro"
-        aria-label="{collapsed ? 'Expand' : 'Collapse'} macro"
+        aria-label="Toggle Macro Collapse"
         aria-expanded={!collapsed}
       >
         <ChevronRightIcon
@@ -168,7 +168,8 @@
         }}
         class="p-1.5 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
         title={isHidden ? "Show Macro" : "Hide Macro"}
-        aria-label={isHidden ? "Show Macro" : "Hide Macro"}
+        aria-label="Toggle Macro Visibility"
+        aria-pressed={!isHidden}
       >
         {#if isHidden}
           <EyeSlashIcon className="size-4 text-neutral-400" strokeWidth={2} />
@@ -179,7 +180,8 @@
 
       <button
         title={macro.locked ? "Unlock Macro" : "Lock Macro"}
-        aria-label={macro.locked ? "Unlock Macro" : "Lock Macro"}
+        aria-label="Toggle Macro Lock"
+        aria-pressed={macro.locked}
         onclick={(e) => {
           e.stopPropagation();
           const idx = sequence.findIndex((s) => (s as any).id === macro.id);

--- a/src/lib/components/sections/PathLineSection.svelte
+++ b/src/lib/components/sections/PathLineSection.svelte
@@ -440,7 +440,8 @@
         }}
         class="p-1.5 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"
         title={isHidden ? "Show Path" : "Hide Path"}
-        aria-label={isHidden ? "Show Path" : "Hide Path"}
+        aria-label="Toggle Path Visibility"
+        aria-pressed={!isHidden}
       >
         {#if isHidden}
           <EyeSlashIcon className="size-4 text-neutral-400" strokeWidth={2} />
@@ -460,7 +461,8 @@
         }}
         class="p-1.5 rounded-md hover:bg-neutral-100 dark:hover:bg-neutral-700 text-neutral-400 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500"
         title={line.locked ? "Unlock Path" : "Lock Path"}
-        aria-label={line.locked ? "Unlock Path" : "Lock Path"}
+        aria-label="Toggle Path Lock"
+        aria-pressed={line.locked}
       >
         {#if line.locked}
           <LockIcon className="size-4 text-amber-500" />

--- a/src/lib/components/table/MacroTableRow.svelte
+++ b/src/lib/components/table/MacroTableRow.svelte
@@ -131,7 +131,7 @@
         onLock();
       }}
       title={isLocked ? "Unlock macro" : "Lock macro"}
-      aria-label={isLocked ? "Unlock macro" : "Lock macro"}
+      aria-label="Toggle Macro Lock"
       class="inline-flex items-center justify-center h-6 w-6 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
       aria-pressed={isLocked}
     >

--- a/src/lib/components/table/RotateTableRow.svelte
+++ b/src/lib/components/table/RotateTableRow.svelte
@@ -176,7 +176,7 @@
         onLock();
       }}
       title={isLocked ? "Unlock rotate" : "Lock rotate"}
-      aria-label={isLocked ? "Unlock rotate" : "Lock rotate"}
+      aria-label="Toggle Rotate Lock"
       class="inline-flex items-center justify-center h-6 w-6 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
       aria-pressed={isLocked}
     >

--- a/src/lib/components/table/WaitTableRow.svelte
+++ b/src/lib/components/table/WaitTableRow.svelte
@@ -168,7 +168,7 @@
         onLock();
       }}
       title={isLocked ? "Unlock wait" : "Lock wait"}
-      aria-label={isLocked ? "Unlock wait" : "Lock wait"}
+      aria-label="Toggle Wait Lock"
       class="inline-flex items-center justify-center h-6 w-6 p-0.5 rounded hover:bg-neutral-200 dark:hover:bg-neutral-700 transition-colors"
       aria-pressed={isLocked}
     >

--- a/src/lib/components/tools/CollapseAllButton.svelte
+++ b/src/lib/components/tools/CollapseAllButton.svelte
@@ -11,11 +11,9 @@
 <button
   onclick={() => onToggle && onToggle()}
   class="text-sm mb-2 px-2 py-1 rounded bg-neutral-100 dark:bg-neutral-800 text-neutral-700 dark:text-neutral-300 hover:bg-neutral-200 dark:hover:bg-neutral-700 border border-neutral-200 dark:border-neutral-700"
-  aria-label={allCollapsed ? "Expand All" : "Collapse All"}
+  aria-expanded={!allCollapsed}
 >
-  {#if allCollapsed}
-    <span class="whitespace-nowrap">Expand All</span>
-  {:else}
-    <span class="whitespace-nowrap">Collapse All</span>
-  {/if}
+  <span class="whitespace-nowrap"
+    >{allCollapsed ? "Expand All" : "Collapse All"}</span
+  >
 </button>

--- a/src/tests/PlaybackControls.test.ts
+++ b/src/tests/PlaybackControls.test.ts
@@ -26,7 +26,7 @@ describe("PlaybackControls", () => {
       props: createProps({ play }),
     });
 
-    const btn = screen.getByLabelText("Play animation");
+    const btn = screen.getByLabelText("Toggle Animation Playback");
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);
@@ -39,7 +39,7 @@ describe("PlaybackControls", () => {
       props: createProps({ playing: true, pause }),
     });
 
-    const btn = screen.getByLabelText("Pause animation");
+    const btn = screen.getByLabelText("Toggle Animation Playback");
     expect(btn).toBeInTheDocument();
 
     await fireEvent.click(btn);


### PR DESCRIPTION
This PR addresses the user directive to improve the accessibility of the program by standardizing how toggle buttons announce themselves to screen readers. 

**What:**
It refactors toggle buttons to use a static, descriptive `aria-label` combined with an `aria-pressed` or `aria-expanded` state attribute, moving away from dynamically changing labels.

**Why:**
Dynamically swapping an `aria-label` (e.g., from "Show Path" to "Hide Path") can confuse screen reader users and lose the element's identity. Using standard ARIA toggle button patterns communicates both the purpose of the button and its current active/inactive state reliably.

**Behavior:**
Visually, the tooltips and buttons work exactly the same. For screen reader users, the buttons will now reliably announce their role as a switch/toggle and their state (pressed or not pressed).

**Verification:**
The entire test suite was run (`npm run test`) and all 1224 tests pass, including updated Playwright/Testing Library queries that matched the old dynamic labels.

---
*PR created automatically by Jules for task [6876785041931909198](https://jules.google.com/task/6876785041931909198) started by @Mallen220*